### PR TITLE
Feature/repositories changes

### DIFF
--- a/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IBikesRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IBikesRepository.cs
@@ -7,7 +7,10 @@ namespace BikesRentalServer.DataAccess.Repositories.Abstract
     {
         IEnumerable<Bike> GetBlocked();
         Bike SetStatus(string id, BikeStatus status);
+        Bike SetStatus(int id, BikeStatus status);
         Bike Associate(string id, User user);
+        Bike Associate(int id, User user);
         Bike Associate(string id, Station station);
+        Bike Associate(int id, Station station);
     }
 }

--- a/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IBikesRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IBikesRepository.cs
@@ -7,7 +7,7 @@ namespace BikesRentalServer.DataAccess.Repositories.Abstract
     {
         IEnumerable<Bike> GetBlocked();
         Bike SetStatus(int id, BikeStatus status);
-        Bike Associate(int id, User user);
-        Bike Associate(int id, Station station);
+        Bike AssociateWithUser(int bikeId, int userId);
+        Bike AssociateWithStation(int bikeId, int stationId);
     }
 }

--- a/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IBikesRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IBikesRepository.cs
@@ -6,11 +6,8 @@ namespace BikesRentalServer.DataAccess.Repositories.Abstract
     public interface IBikesRepository : IRepository<Bike>
     {
         IEnumerable<Bike> GetBlocked();
-        Bike SetStatus(string id, BikeStatus status);
         Bike SetStatus(int id, BikeStatus status);
-        Bike Associate(string id, User user);
         Bike Associate(int id, User user);
-        Bike Associate(string id, Station station);
         Bike Associate(int id, Station station);
     }
 }

--- a/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IRepository.cs
@@ -6,8 +6,10 @@ namespace BikesRentalServer.DataAccess.Repositories.Abstract
     {
         IEnumerable<T> GetAll();
         T Get(string id);
+        T Get(int id);
         T Add(T entity);
         T Remove(string id);
+        T Remove(int id);
         T Remove(T entity);
     }
 }

--- a/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IRepository.cs
@@ -10,6 +10,5 @@ namespace BikesRentalServer.DataAccess.Repositories.Abstract
         T Add(T entity);
         T Remove(string id);
         T Remove(int id);
-        T Remove(T entity);
     }
 }

--- a/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IRepository.cs
@@ -6,7 +6,6 @@ namespace BikesRentalServer.DataAccess.Repositories.Abstract
     {
         IEnumerable<T> GetAll();
         T Get(string id);
-        T Get(int id);
         T Add(T entity);
         T Remove(int id);
     }

--- a/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IRepository.cs
@@ -8,7 +8,6 @@ namespace BikesRentalServer.DataAccess.Repositories.Abstract
         T Get(string id);
         T Get(int id);
         T Add(T entity);
-        T Remove(string id);
         T Remove(int id);
     }
 }

--- a/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IReservationsRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IReservationsRepository.cs
@@ -5,9 +5,7 @@ namespace BikesRentalServer.DataAccess.Repositories.Abstract
 {
     public interface IReservationsRepository : IRepository<Reservation>
     {
-        Reservation GetActiveReservation(string bikeId);
         Reservation GetActiveReservation(int bikeId);
-        IEnumerable<Reservation> GetActiveReservations(string userId);
         IEnumerable<Reservation> GetActiveReservations(int userId);
     }
 }

--- a/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IReservationsRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IReservationsRepository.cs
@@ -6,6 +6,8 @@ namespace BikesRentalServer.DataAccess.Repositories.Abstract
     public interface IReservationsRepository : IRepository<Reservation>
     {
         Reservation GetActiveReservation(string bikeId);
+        Reservation GetActiveReservation(int bikeId);
         IEnumerable<Reservation> GetActiveReservations(string userId);
+        IEnumerable<Reservation> GetActiveReservations(int userId);
     }
 }

--- a/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IReservationsRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IReservationsRepository.cs
@@ -6,6 +6,6 @@ namespace BikesRentalServer.DataAccess.Repositories.Abstract
     public interface IReservationsRepository : IRepository<Reservation>
     {
         Reservation GetActiveReservation(string bikeId);
-        List<Reservation> GetActiveReservations(string userId);
+        IEnumerable<Reservation> GetActiveReservations(string userId);
     }
 }

--- a/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IStationsRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IStationsRepository.cs
@@ -7,7 +7,6 @@ namespace BikesRentalServer.DataAccess.Repositories.Abstract
     {
         IEnumerable<Station> GetActive();
         IEnumerable<Station> GetBlocked();
-        Station SetStatus(string id, StationStatus status);
         Station SetStatus(int id, StationStatus status);
     }
 }

--- a/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IStationsRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IStationsRepository.cs
@@ -8,5 +8,6 @@ namespace BikesRentalServer.DataAccess.Repositories.Abstract
         IEnumerable<Station> GetActive();
         IEnumerable<Station> GetBlocked();
         Station SetStatus(string id, StationStatus status);
+        Station SetStatus(int id, StationStatus status);
     }
 }

--- a/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IUsersRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IUsersRepository.cs
@@ -8,7 +8,6 @@ namespace BikesRentalServer.DataAccess.Repositories.Abstract
         IEnumerable<User> GetBlockedUsers();
         User GetByUsername(string username);
         User GetByUsernameAndPassword(string username, string password);
-        User SetStatus(string id, UserStatus status);
         User SetStatus(int id, UserStatus status);
     }
 }

--- a/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IUsersRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/Abstract/IUsersRepository.cs
@@ -9,5 +9,6 @@ namespace BikesRentalServer.DataAccess.Repositories.Abstract
         User GetByUsername(string username);
         User GetByUsernameAndPassword(string username, string password);
         User SetStatus(string id, UserStatus status);
+        User SetStatus(int id, UserStatus status);
     }
 }

--- a/Backend/BikesRentalServer.DataAccess/Repositories/BikesRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/BikesRepository.cs
@@ -74,10 +74,11 @@ namespace BikesRentalServer.DataAccess.Repositories
             return bike;
         }
 
-        public Bike Associate(int id, User user)
+        public Bike AssociateWithUser(int bikeId, int userId)
         {
-            var bike = Get(id);
-            if (bike is null || !_dbContext.Users.Contains(user))
+            var bike = Get(bikeId);
+            var user = _dbContext.Users.SingleOrDefault(u => u.Id == userId);
+            if (bike is null || user is null)
                 return null;
 
             bike.Station = null;
@@ -87,10 +88,11 @@ namespace BikesRentalServer.DataAccess.Repositories
             return bike;
         }
 
-        public Bike Associate(int id, Station station)
+        public Bike AssociateWithStation(int bikeId, int stationId)
         {
-            var bike = Get(id);
-            if (bike is null || !_dbContext.Stations.Contains(station))
+            var bike = Get(bikeId);
+            var station = _dbContext.Stations.SingleOrDefault(u => u.Id == stationId);
+            if (bike is null || station is null)
                 return null;
 
             bike.User = null;

--- a/Backend/BikesRentalServer.DataAccess/Repositories/BikesRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/BikesRepository.cs
@@ -75,17 +75,6 @@ namespace BikesRentalServer.DataAccess.Repositories
             return bike;
         }
 
-        public Bike Remove(Bike entity)
-        {
-            if (!_dbContext.Bikes.Contains(entity))
-                return null;
-            
-            var bike = _dbContext.Bikes.Remove(entity).Entity;
-            _dbContext.SaveChanges();
-
-            return bike;
-        }
-
         public IEnumerable<Bike> GetBlocked()
         {
             return _dbContext.Bikes
@@ -95,6 +84,18 @@ namespace BikesRentalServer.DataAccess.Repositories
         }
 
         public Bike SetStatus(string id, BikeStatus status)
+        {
+            var bike = Get(id);
+            if (bike is null)
+                return null;
+
+            bike.Status = status;
+            _dbContext.SaveChanges();
+
+            return bike;
+        }
+
+        public Bike SetStatus(int id, BikeStatus status)
         {
             var bike = Get(id);
             if (bike is null)
@@ -119,7 +120,33 @@ namespace BikesRentalServer.DataAccess.Repositories
             return bike;
         }
 
+        public Bike Associate(int id, User user)
+        {
+            var bike = Get(id);
+            if (bike is null || !_dbContext.Users.Contains(user))
+                return null;
+
+            bike.Station = null;
+            bike.User = user;
+            _dbContext.SaveChanges();
+
+            return bike;
+        }
+
         public Bike Associate(string id, Station station)
+        {
+            var bike = Get(id);
+            if (bike is null || !_dbContext.Stations.Contains(station))
+                return null;
+
+            bike.User = null;
+            bike.Station = station;
+            _dbContext.SaveChanges();
+
+            return bike;
+        }
+
+        public Bike Associate(int id, Station station)
         {
             var bike = Get(id);
             if (bike is null || !_dbContext.Stations.Contains(station))

--- a/Backend/BikesRentalServer.DataAccess/Repositories/BikesRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/BikesRepository.cs
@@ -34,30 +34,9 @@ namespace BikesRentalServer.DataAccess.Repositories
                 .SingleOrDefault(b => b.Id == iid);
         }
 
-        public Bike Get(int id)
-        {
-            return _dbContext.Bikes
-                .Include(b => b.Station)
-                .ThenInclude(s => s.Bikes)
-                .Include(b => b.User)
-                .SingleOrDefault(b => b.Id == id);
-        }
-
         public Bike Add(Bike entity)
         {
             var bike = _dbContext.Bikes.Add(entity).Entity;
-            _dbContext.SaveChanges();
-
-            return bike;
-        }
-
-        public Bike Remove(string id)
-        {
-            var bike = Get(id);
-            if (bike is null)
-                return null;
-
-            _dbContext.Bikes.Remove(bike);
             _dbContext.SaveChanges();
 
             return bike;
@@ -83,18 +62,6 @@ namespace BikesRentalServer.DataAccess.Repositories
                 .Include(b => b.User);
         }
 
-        public Bike SetStatus(string id, BikeStatus status)
-        {
-            var bike = Get(id);
-            if (bike is null)
-                return null;
-
-            bike.Status = status;
-            _dbContext.SaveChanges();
-
-            return bike;
-        }
-
         public Bike SetStatus(int id, BikeStatus status)
         {
             var bike = Get(id);
@@ -102,19 +69,6 @@ namespace BikesRentalServer.DataAccess.Repositories
                 return null;
 
             bike.Status = status;
-            _dbContext.SaveChanges();
-
-            return bike;
-        }
-
-        public Bike Associate(string id, User user)
-        {
-            var bike = Get(id);
-            if (bike is null || !_dbContext.Users.Contains(user))
-                return null;
-
-            bike.Station = null;
-            bike.User = user;
             _dbContext.SaveChanges();
 
             return bike;
@@ -133,19 +87,6 @@ namespace BikesRentalServer.DataAccess.Repositories
             return bike;
         }
 
-        public Bike Associate(string id, Station station)
-        {
-            var bike = Get(id);
-            if (bike is null || !_dbContext.Stations.Contains(station))
-                return null;
-
-            bike.User = null;
-            bike.Station = station;
-            _dbContext.SaveChanges();
-
-            return bike;
-        }
-
         public Bike Associate(int id, Station station)
         {
             var bike = Get(id);
@@ -158,5 +99,7 @@ namespace BikesRentalServer.DataAccess.Repositories
 
             return bike;
         }
+
+        private Bike Get(int id) => Get(id.ToString());
     }
 }

--- a/Backend/BikesRentalServer.DataAccess/Repositories/BikesRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/BikesRepository.cs
@@ -17,14 +17,30 @@ namespace BikesRentalServer.DataAccess.Repositories
         
         public IEnumerable<Bike> GetAll()
         {
-            return _dbContext.Bikes.Include(b => b.Station).ThenInclude(s => s.Bikes).Include(b => b.User);
+            return _dbContext.Bikes
+                .Include(b => b.Station)
+                .ThenInclude(s => s.Bikes)
+                .Include(b => b.User);
         }
 
         public Bike Get(string id)
         {
             if (!int.TryParse(id, out var iid))
                 return null;
-            return _dbContext.Bikes.Include(b => b.Station).ThenInclude(s => s.Bikes).Include(b => b.User).SingleOrDefault(b => b.Id == iid);
+            return _dbContext.Bikes
+                .Include(b => b.Station)
+                .ThenInclude(s => s.Bikes)
+                .Include(b => b.User)
+                .SingleOrDefault(b => b.Id == iid);
+        }
+
+        public Bike Get(int id)
+        {
+            return _dbContext.Bikes
+                .Include(b => b.Station)
+                .ThenInclude(s => s.Bikes)
+                .Include(b => b.User)
+                .SingleOrDefault(b => b.Id == id);
         }
 
         public Bike Add(Bike entity)
@@ -36,6 +52,18 @@ namespace BikesRentalServer.DataAccess.Repositories
         }
 
         public Bike Remove(string id)
+        {
+            var bike = Get(id);
+            if (bike is null)
+                return null;
+
+            _dbContext.Bikes.Remove(bike);
+            _dbContext.SaveChanges();
+
+            return bike;
+        }
+
+        public Bike Remove(int id)
         {
             var bike = Get(id);
             if (bike is null)
@@ -60,7 +88,10 @@ namespace BikesRentalServer.DataAccess.Repositories
 
         public IEnumerable<Bike> GetBlocked()
         {
-            return _dbContext.Bikes.Where(b => b.Status == BikeStatus.Blocked).Include(b => b.Station).Include(b => b.User);
+            return _dbContext.Bikes
+                .Where(b => b.Status == BikeStatus.Blocked)
+                .Include(b => b.Station)
+                .Include(b => b.User);
         }
 
         public Bike SetStatus(string id, BikeStatus status)

--- a/Backend/BikesRentalServer.DataAccess/Repositories/ReservationsRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/ReservationsRepository.cs
@@ -74,17 +74,6 @@ namespace BikesRentalServer.DataAccess.Repositories
             return reservation;
         }
 
-        public Reservation Remove(Reservation entity)
-        {
-            if (!_dbContext.Reservations.Contains(entity))
-                return null;
-            
-            var reservation = _dbContext.Reservations.Remove(entity).Entity;
-            _dbContext.SaveChanges();
-
-            return reservation;
-        }
-
         public Reservation GetActiveReservation(string bikeId)
         {
             if (!int.TryParse(bikeId, out var iid))
@@ -95,6 +84,14 @@ namespace BikesRentalServer.DataAccess.Repositories
                 .SingleOrDefault(r => r.Bike.Id == iid && r.ExpirationDate > DateTime.Now);
         }
 
+        public Reservation GetActiveReservation(int bikeId)
+        {
+            return _dbContext.Reservations
+                .Include(r => r.Bike)
+                .Include(r => r.User)
+                .SingleOrDefault(r => r.Bike.Id == bikeId && r.ExpirationDate > DateTime.Now);
+        }
+
         public IEnumerable<Reservation> GetActiveReservations(string userId)
         {
             if (!int.TryParse(userId, out var iid))
@@ -103,6 +100,14 @@ namespace BikesRentalServer.DataAccess.Repositories
                 .Include(r => r.Bike)
                 .Include(r => r.User)
                 .Where(r => r.User.Id == iid && r.ExpirationDate > DateTime.Now);
+        }
+
+        public IEnumerable<Reservation> GetActiveReservations(int userId)
+        {
+            return _dbContext.Reservations
+                .Include(r => r.Bike)
+                .Include(r => r.User)
+                .Where(r => r.User.Id == userId && r.ExpirationDate > DateTime.Now);
         }
     }
 }

--- a/Backend/BikesRentalServer.DataAccess/Repositories/ReservationsRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/ReservationsRepository.cs
@@ -18,14 +18,29 @@ namespace BikesRentalServer.DataAccess.Repositories
 
         public IEnumerable<Reservation> GetAll()
         {
-            return _dbContext.Reservations.Include(r => r.Bike).Include(r => r.User);
+            return _dbContext.Reservations
+                .Include(r => r.Bike)
+                .Include(r => r.User)
+                .ToList();
         }
 
         public Reservation Get(string id)
         {
             if (!int.TryParse(id, out var iid))
                 return null;
-            return _dbContext.Reservations.Include(r => r.Bike).Include(r => r.User).SingleOrDefault(r => r.Id == iid);
+            
+            return _dbContext.Reservations
+                .Include(r => r.Bike)
+                .Include(r => r.User)
+                .SingleOrDefault(r => r.Id == iid);
+        }
+
+        public Reservation Get(int id)
+        {
+            return _dbContext.Reservations
+                .Include(r => r.Bike)
+                .Include(r => r.User)
+                .SingleOrDefault(r => r.Id == id);
         }
 
         public Reservation Add(Reservation entity)
@@ -37,6 +52,18 @@ namespace BikesRentalServer.DataAccess.Repositories
         }
 
         public Reservation Remove(string id)
+        {
+            var reservation = Get(id);
+            if (reservation is null)
+                return null;
+
+            _dbContext.Reservations.Remove(reservation);
+            _dbContext.SaveChanges();
+
+            return reservation;
+        }
+
+        public Reservation Remove(int id)
         {
             var reservation = Get(id);
             if (reservation is null)
@@ -63,14 +90,21 @@ namespace BikesRentalServer.DataAccess.Repositories
         {
             if (!int.TryParse(bikeId, out var iid))
                 return null;
-            return _dbContext.Reservations.Include(r => r.Bike).Include(r => r.User).SingleOrDefault(r => r.Bike.Id == iid && r.ExpirationDate > DateTime.Now);
+            return _dbContext.Reservations
+                .Include(r => r.Bike)
+                .Include(r => r.User)
+                .SingleOrDefault(r => r.Bike.Id == iid && r.ExpirationDate > DateTime.Now);
         }
 
         public List<Reservation> GetActiveReservations(string userId)
         {
             if (!int.TryParse(userId, out var iid))
                 return null;
-            return _dbContext.Reservations.Include(r => r.Bike).Include(r => r.User).Where(r => r.User.Id == iid && r.ExpirationDate > DateTime.Now).ToList();
+            return _dbContext.Reservations
+                .Include(r => r.Bike)
+                .Include(r => r.User)
+                .Where(r => r.User.Id == iid && r.ExpirationDate > DateTime.Now)
+                .ToList();
         }
     }
 }

--- a/Backend/BikesRentalServer.DataAccess/Repositories/ReservationsRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/ReservationsRepository.cs
@@ -20,8 +20,7 @@ namespace BikesRentalServer.DataAccess.Repositories
         {
             return _dbContext.Reservations
                 .Include(r => r.Bike)
-                .Include(r => r.User)
-                .ToList();
+                .Include(r => r.User);
         }
 
         public Reservation Get(string id)
@@ -96,15 +95,14 @@ namespace BikesRentalServer.DataAccess.Repositories
                 .SingleOrDefault(r => r.Bike.Id == iid && r.ExpirationDate > DateTime.Now);
         }
 
-        public List<Reservation> GetActiveReservations(string userId)
+        public IEnumerable<Reservation> GetActiveReservations(string userId)
         {
             if (!int.TryParse(userId, out var iid))
                 return null;
             return _dbContext.Reservations
                 .Include(r => r.Bike)
                 .Include(r => r.User)
-                .Where(r => r.User.Id == iid && r.ExpirationDate > DateTime.Now)
-                .ToList();
+                .Where(r => r.User.Id == iid && r.ExpirationDate > DateTime.Now);
         }
     }
 }

--- a/Backend/BikesRentalServer.DataAccess/Repositories/ReservationsRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/ReservationsRepository.cs
@@ -34,29 +34,9 @@ namespace BikesRentalServer.DataAccess.Repositories
                 .SingleOrDefault(r => r.Id == iid);
         }
 
-        public Reservation Get(int id)
-        {
-            return _dbContext.Reservations
-                .Include(r => r.Bike)
-                .Include(r => r.User)
-                .SingleOrDefault(r => r.Id == id);
-        }
-
         public Reservation Add(Reservation entity)
         {
             var reservation = _dbContext.Reservations.Add(entity).Entity;
-            _dbContext.SaveChanges();
-
-            return reservation;
-        }
-
-        public Reservation Remove(string id)
-        {
-            var reservation = Get(id);
-            if (reservation is null)
-                return null;
-
-            _dbContext.Reservations.Remove(reservation);
             _dbContext.SaveChanges();
 
             return reservation;
@@ -74,32 +54,12 @@ namespace BikesRentalServer.DataAccess.Repositories
             return reservation;
         }
 
-        public Reservation GetActiveReservation(string bikeId)
-        {
-            if (!int.TryParse(bikeId, out var iid))
-                return null;
-            return _dbContext.Reservations
-                .Include(r => r.Bike)
-                .Include(r => r.User)
-                .SingleOrDefault(r => r.Bike.Id == iid && r.ExpirationDate > DateTime.Now);
-        }
-
         public Reservation GetActiveReservation(int bikeId)
         {
             return _dbContext.Reservations
                 .Include(r => r.Bike)
                 .Include(r => r.User)
                 .SingleOrDefault(r => r.Bike.Id == bikeId && r.ExpirationDate > DateTime.Now);
-        }
-
-        public IEnumerable<Reservation> GetActiveReservations(string userId)
-        {
-            if (!int.TryParse(userId, out var iid))
-                return null;
-            return _dbContext.Reservations
-                .Include(r => r.Bike)
-                .Include(r => r.User)
-                .Where(r => r.User.Id == iid && r.ExpirationDate > DateTime.Now);
         }
 
         public IEnumerable<Reservation> GetActiveReservations(int userId)
@@ -109,5 +69,7 @@ namespace BikesRentalServer.DataAccess.Repositories
                 .Include(r => r.User)
                 .Where(r => r.User.Id == userId && r.ExpirationDate > DateTime.Now);
         }
+
+        private Reservation Get(int id) => Get(id.ToString());
     }
 }

--- a/Backend/BikesRentalServer.DataAccess/Repositories/StationsRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/StationsRepository.cs
@@ -24,7 +24,16 @@ namespace BikesRentalServer.DataAccess.Repositories
         {
             if (!int.TryParse(id, out var iid))
                 return null;
-            return _dbContext.Stations.Include(s => s.Bikes).SingleOrDefault(s => s.Id == iid);
+            return _dbContext.Stations
+                .Include(s => s.Bikes)
+                .SingleOrDefault(s => s.Id == iid);
+        }
+
+        public Station Get(int id)
+        {
+            return _dbContext.Stations
+                .Include(s => s.Bikes)
+                .SingleOrDefault(s => s.Id == id);
         }
 
         public Station Add(Station entity)
@@ -37,6 +46,18 @@ namespace BikesRentalServer.DataAccess.Repositories
         }
 
         public Station Remove(string id)
+        {
+            var station = Get(id);
+            if (station is null)
+                return null;
+
+            _dbContext.Stations.Remove(station);
+            _dbContext.SaveChanges();
+
+            return station;
+        }
+
+        public Station Remove(int id)
         {
             var station = Get(id);
             if (station is null)
@@ -61,12 +82,16 @@ namespace BikesRentalServer.DataAccess.Repositories
 
         public IEnumerable<Station> GetActive()
         {
-            return _dbContext.Stations.Where(s => s.Status == StationStatus.Active).Include(s => s.Bikes);
+            return _dbContext.Stations
+                .Where(s => s.Status == StationStatus.Active)
+                .Include(s => s.Bikes);
         }
         
         public IEnumerable<Station> GetBlocked()
         {
-            return _dbContext.Stations.Where(s => s.Status == StationStatus.Blocked).Include(s => s.Bikes);
+            return _dbContext.Stations
+                .Where(s => s.Status == StationStatus.Blocked)
+                .Include(s => s.Bikes);
         }
 
         public Station SetStatus(string id, StationStatus status)

--- a/Backend/BikesRentalServer.DataAccess/Repositories/StationsRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/StationsRepository.cs
@@ -29,29 +29,10 @@ namespace BikesRentalServer.DataAccess.Repositories
                 .SingleOrDefault(s => s.Id == iid);
         }
 
-        public Station Get(int id)
-        {
-            return _dbContext.Stations
-                .Include(s => s.Bikes)
-                .SingleOrDefault(s => s.Id == id);
-        }
-
         public Station Add(Station entity)
         {
             var station = _dbContext.Stations.Add(entity).Entity;
             _dbContext.Entry(station).Collection(s => s.Bikes).Load();
-            _dbContext.SaveChanges();
-
-            return station;
-        }
-
-        public Station Remove(string id)
-        {
-            var station = Get(id);
-            if (station is null)
-                return null;
-
-            _dbContext.Stations.Remove(station);
             _dbContext.SaveChanges();
 
             return station;
@@ -83,18 +64,6 @@ namespace BikesRentalServer.DataAccess.Repositories
                 .Include(s => s.Bikes);
         }
 
-        public Station SetStatus(string id, StationStatus status)
-        {
-            var station = Get(id);
-            if (station is null)
-                return null;
-
-            station.Status = status;
-            _dbContext.SaveChanges();
-
-            return station;
-        }
-
         public Station SetStatus(int id, StationStatus status)
         {
             var station = Get(id);
@@ -106,5 +75,7 @@ namespace BikesRentalServer.DataAccess.Repositories
 
             return station;
         }
+
+        private Station Get(int id) => Get(id.ToString());
     }
 }

--- a/Backend/BikesRentalServer.DataAccess/Repositories/StationsRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/StationsRepository.cs
@@ -69,17 +69,6 @@ namespace BikesRentalServer.DataAccess.Repositories
             return station;
         }
 
-        public Station Remove(Station entity)
-        {
-            if (!_dbContext.Stations.Contains(entity))
-                return null;
-            
-            var station = _dbContext.Stations.Remove(entity).Entity;
-            _dbContext.SaveChanges();
-
-            return station;
-        }
-
         public IEnumerable<Station> GetActive()
         {
             return _dbContext.Stations
@@ -95,6 +84,18 @@ namespace BikesRentalServer.DataAccess.Repositories
         }
 
         public Station SetStatus(string id, StationStatus status)
+        {
+            var station = Get(id);
+            if (station is null)
+                return null;
+
+            station.Status = status;
+            _dbContext.SaveChanges();
+
+            return station;
+        }
+
+        public Station SetStatus(int id, StationStatus status)
         {
             var station = Get(id);
             if (station is null)

--- a/Backend/BikesRentalServer.DataAccess/Repositories/UsersRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/UsersRepository.cs
@@ -73,17 +73,6 @@ namespace BikesRentalServer.DataAccess.Repositories
             return user;
         }
 
-        public User Remove(User entity)
-        {
-            if (!_dbContext.Users.Contains(entity))
-                return null;
-            
-            var user = _dbContext.Users.Remove(entity).Entity;
-            _dbContext.SaveChanges();
-
-            return user;
-        }
-
         public IEnumerable<User> GetBlockedUsers()
         {
             return _dbContext.Users
@@ -109,6 +98,18 @@ namespace BikesRentalServer.DataAccess.Repositories
         }
 
         public User SetStatus(string id, UserStatus status)
+        {
+            var user = Get(id);
+            if (user is null)
+                return null;
+
+            user.Status = status;
+            _dbContext.SaveChanges();
+
+            return user;
+        }
+
+        public User SetStatus(int id, UserStatus status)
         {
             var user = Get(id);
             if (user is null)

--- a/Backend/BikesRentalServer.DataAccess/Repositories/UsersRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/UsersRepository.cs
@@ -33,29 +33,9 @@ namespace BikesRentalServer.DataAccess.Repositories
                 .SingleOrDefault(u => u.Id == iid && u.Role == UserRole.User);
         }
 
-        public User Get(int id)
-        {
-            return _dbContext.Users.Include(u => u.RentedBikes)
-                .Include(u => u.Reservations)
-                .ThenInclude(r => r.Bike)
-                .SingleOrDefault(u => u.Id == id && u.Role == UserRole.User);
-        }
-
         public User Add(User entity)
         {
             var user = _dbContext.Users.Add(entity).Entity;
-            _dbContext.SaveChanges();
-
-            return user;
-        }
-
-        public User Remove(string id)
-        {
-            var user = Get(id);
-            if (user is null)
-                return null;
-
-            _dbContext.Users.Remove(user);
             _dbContext.SaveChanges();
 
             return user;
@@ -97,18 +77,6 @@ namespace BikesRentalServer.DataAccess.Repositories
                 .SingleOrDefault(u => u.Username == username && u.PasswordHash == Toolbox.ComputeHash(password));
         }
 
-        public User SetStatus(string id, UserStatus status)
-        {
-            var user = Get(id);
-            if (user is null)
-                return null;
-
-            user.Status = status;
-            _dbContext.SaveChanges();
-
-            return user;
-        }
-
         public User SetStatus(int id, UserStatus status)
         {
             var user = Get(id);
@@ -120,5 +88,7 @@ namespace BikesRentalServer.DataAccess.Repositories
 
             return user;
         }
+
+        private User Get(int id) => Get(id.ToString());
     }
 }

--- a/Backend/BikesRentalServer.DataAccess/Repositories/UsersRepository.cs
+++ b/Backend/BikesRentalServer.DataAccess/Repositories/UsersRepository.cs
@@ -17,14 +17,28 @@ namespace BikesRentalServer.DataAccess.Repositories
         
         public IEnumerable<User> GetAll()
         {
-            return _dbContext.Users.Include(u => u.RentedBikes).Include(u => u.Reservations).Where(u => u.Role == UserRole.User);
+            return _dbContext.Users
+                .Include(u => u.RentedBikes)
+                .Include(u => u.Reservations)
+                .Where(u => u.Role == UserRole.User);
         }
 
         public User Get(string id)
         {
             if (!int.TryParse(id, out var iid))
                 return null;
-            return _dbContext.Users.Include(u => u.RentedBikes).Include(u => u.Reservations).ThenInclude(r => r.Bike).SingleOrDefault(u => u.Id == iid && u.Role == UserRole.User);
+            return _dbContext.Users.Include(u => u.RentedBikes)
+                .Include(u => u.Reservations)
+                .ThenInclude(r => r.Bike)
+                .SingleOrDefault(u => u.Id == iid && u.Role == UserRole.User);
+        }
+
+        public User Get(int id)
+        {
+            return _dbContext.Users.Include(u => u.RentedBikes)
+                .Include(u => u.Reservations)
+                .ThenInclude(r => r.Bike)
+                .SingleOrDefault(u => u.Id == id && u.Role == UserRole.User);
         }
 
         public User Add(User entity)
@@ -36,6 +50,18 @@ namespace BikesRentalServer.DataAccess.Repositories
         }
 
         public User Remove(string id)
+        {
+            var user = Get(id);
+            if (user is null)
+                return null;
+
+            _dbContext.Users.Remove(user);
+            _dbContext.SaveChanges();
+
+            return user;
+        }
+
+        public User Remove(int id)
         {
             var user = Get(id);
             if (user is null)
@@ -60,12 +86,18 @@ namespace BikesRentalServer.DataAccess.Repositories
 
         public IEnumerable<User> GetBlockedUsers()
         {
-            return _dbContext.Users.Include(u => u.RentedBikes).Include(u => u.Reservations).Where(u => u.Role == UserRole.User && u.Status == UserStatus.Blocked);
+            return _dbContext.Users
+                .Include(u => u.RentedBikes)
+                .Include(u => u.Reservations)
+                .Where(u => u.Role == UserRole.User && u.Status == UserStatus.Blocked);
         }
 
         public User GetByUsername(string username)
         {
-            return _dbContext.Users.Include(u => u.RentedBikes).Include(u => u.Reservations).SingleOrDefault(u => u.Username == username);
+            return _dbContext.Users
+                .Include(u => u.RentedBikes)
+                .Include(u => u.Reservations)
+                .SingleOrDefault(u => u.Username == username);
         }
 
         public User GetByUsernameAndPassword(string username, string password)

--- a/Backend/BikesRentalServer.Services/Abstract/IUsersService.cs
+++ b/Backend/BikesRentalServer.Services/Abstract/IUsersService.cs
@@ -18,8 +18,8 @@ namespace BikesRentalServer.Services.Abstract
         #region Blocking
 
         ServiceActionResult<IEnumerable<User>> GetBlockedUsers();
-        ServiceActionResult<User> BlockUser(string userId);
-        ServiceActionResult<User> UnblockUser(string userId);
+        ServiceActionResult<User> BlockUser(string id);
+        ServiceActionResult<User> UnblockUser(string id);
         
         #endregion
     }

--- a/Backend/BikesRentalServer.Services/BikesService.cs
+++ b/Backend/BikesRentalServer.Services/BikesService.cs
@@ -36,7 +36,7 @@ namespace BikesRentalServer.Services
             var bikes = _bikesRepository.GetAll();
             return ServiceActionResult.Success(bikes.Select(bike =>
             {
-                var reservation = _reservationsRepository.GetActiveReservation(bike.Id.ToString());
+                var reservation = _reservationsRepository.GetActiveReservation(bike.Id);
                 return new Bike
                 {
                     Description = bike.Description,
@@ -54,7 +54,7 @@ namespace BikesRentalServer.Services
             var bike = _bikesRepository.Get(id);
             if (bike is null)
                 return ServiceActionResult.EntityNotFound<Bike>("Bike not found");
-            var reservation = _reservationsRepository.GetActiveReservation(id);
+            var reservation = _reservationsRepository.GetActiveReservation(bike.Id);
             return ServiceActionResult.Success(new Bike
             {
                 Description = bike.Description,
@@ -82,7 +82,7 @@ namespace BikesRentalServer.Services
                 Description = bike.Description,
                 Id = bike.Id,
                 Station = bike.Station,
-                Status = _reservationsRepository.GetActiveReservation(bike.Id.ToString()) is null ? bike.Status : BikeStatus.Reserved,
+                Status = _reservationsRepository.GetActiveReservation(bike.Id) is null ? bike.Status : BikeStatus.Reserved,
                 User = bike.User,
                 StationId = bike.StationId,
             });
@@ -98,13 +98,13 @@ namespace BikesRentalServer.Services
             if (bike.User is not null)
                 throw new InvalidOperationException("Trying to remove rented bike");
 
-            bike = _bikesRepository.Remove(bike);
+            bike = _bikesRepository.Remove(bike.Id);
             return ServiceActionResult.Success(new Bike
             {
                 Description = bike.Description,
                 Id = bike.Id,
                 Station = bike.Station,
-                Status = _reservationsRepository.GetActiveReservation(bike.Id.ToString()) is null ? bike.Status : BikeStatus.Reserved,
+                Status = _reservationsRepository.GetActiveReservation(bike.Id) is null ? bike.Status : BikeStatus.Reserved,
                 User = bike.User,
                 StationId = bike.StationId,
             });
@@ -146,17 +146,17 @@ namespace BikesRentalServer.Services
             if (user.RentedBikes.Count >= 4)
                 return ServiceActionResult.InvalidState<Bike>("Rental limit exceeded");
 
-            var reservation = _reservationsRepository.GetActiveReservation(id);
+            var reservation = _reservationsRepository.GetActiveReservation(bike.Id);
             if (reservation is not null )
             {
                 if (reservation.User.Id != user.Id)
                     return ServiceActionResult.InvalidState<Bike>("Bike is reserved by different user");
 
-                _reservationsRepository.Remove(reservation);
+                _reservationsRepository.Remove(reservation.Id);
             }
 
-            _bikesRepository.SetStatus(id, BikeStatus.Rented);
-            bike = _bikesRepository.Associate(id, user);
+            _bikesRepository.SetStatus(bike.Id, BikeStatus.Rented);
+            bike = _bikesRepository.Associate(bike.Id, user);
             return ServiceActionResult.Success(new Bike
             {
                 Description = bike.Description,
@@ -182,8 +182,8 @@ namespace BikesRentalServer.Services
             if (bike.User.Username != _userContext.Username)
                 return ServiceActionResult.InvalidState<Bike>("Bike not rented by calling user");
 
-            _bikesRepository.SetStatus(bikeId, BikeStatus.Available);
-            bike = _bikesRepository.Associate(bikeId, station);
+            _bikesRepository.SetStatus(bike.Id, BikeStatus.Available);
+            bike = _bikesRepository.Associate(bike.Id, station);
             return ServiceActionResult.Success(new Bike
             {
                 Description = bike.Description,
@@ -225,10 +225,10 @@ namespace BikesRentalServer.Services
                 case BikeStatus.Rented:
                     return ServiceActionResult.InvalidState<Bike>("Bike is rented");
                 default:
-                    bike = _bikesRepository.SetStatus(id, BikeStatus.Blocked);
-                    var reservation = _reservationsRepository.GetActiveReservation(bike.Id.ToString());
+                    bike = _bikesRepository.SetStatus(bike.Id, BikeStatus.Blocked);
+                    var reservation = _reservationsRepository.GetActiveReservation(bike.Id);
                     if (reservation is not null)
-                        _reservationsRepository.Remove(reservation);
+                        _reservationsRepository.Remove(reservation.Id);
                     return ServiceActionResult.Success(new Bike
                     {
                         Description = bike.Description,
@@ -249,7 +249,7 @@ namespace BikesRentalServer.Services
             if (bike.Status is BikeStatus.Available)
                 return ServiceActionResult.InvalidState<Bike>("Bike not blocked");
 
-            bike = _bikesRepository.SetStatus(id, BikeStatus.Available);
+            bike = _bikesRepository.SetStatus(bike.Id, BikeStatus.Available);
             return ServiceActionResult.Success(new Bike
             {
                 Description = bike.Description,
@@ -268,7 +268,7 @@ namespace BikesRentalServer.Services
         public ServiceActionResult<IEnumerable<Bike>> GetReservedBikes()
         {
             var user = _usersRepository.GetByUsername(_userContext.Username);
-            var reservations = _reservationsRepository.GetActiveReservations(user.Id.ToString());
+            var reservations = _reservationsRepository.GetActiveReservations(user.Id);
             var reservedBikes = reservations.Select(reservation => reservation.Bike);
             return ServiceActionResult.Success(reservedBikes.Select(bike => new Bike
             {
@@ -294,14 +294,14 @@ namespace BikesRentalServer.Services
                 return ServiceActionResult.InvalidState<Reservation>("Bike is rented");
             if (bike.Station.Status is StationStatus.Blocked)
                 return ServiceActionResult.InvalidState<Reservation>("Station is blocked");
-            if (_reservationsRepository.GetActiveReservation(id) is not null)
+            if (_reservationsRepository.GetActiveReservation(bike.Id) is not null)
                 return ServiceActionResult.InvalidState<Reservation>("Reservation for bike exists");
 
             var user = _usersRepository.GetByUsername(_userContext.Username);
             if (user.Status is UserStatus.Blocked)
                 return ServiceActionResult.UserBlocked<Reservation>("User is blocked");
 
-            bike = _bikesRepository.SetStatus(id, BikeStatus.Reserved);
+            bike = _bikesRepository.SetStatus(bike.Id, BikeStatus.Reserved);
             var reservation = _reservationsRepository.Add(new Reservation
             {
                 User = user,
@@ -325,12 +325,12 @@ namespace BikesRentalServer.Services
             if (bike is null)
                 return ServiceActionResult.EntityNotFound<Bike>("Bike not found");
 
-            var reservation = _reservationsRepository.GetActiveReservation(bikeId);
+            var reservation = _reservationsRepository.GetActiveReservation(bike.Id);
             if (reservation is null)
                 return ServiceActionResult.InvalidState<Bike>("Bike is not reserved");
 
-            _bikesRepository.SetStatus(bikeId, BikeStatus.Available);
-            _reservationsRepository.Remove(reservation);
+            _bikesRepository.SetStatus(bike.Id, BikeStatus.Available);
+            _reservationsRepository.Remove(reservation.Id);
             return ServiceActionResult.Success(new Bike
             {
                 Description = reservation.Bike.Description,

--- a/Backend/BikesRentalServer.Services/BikesService.cs
+++ b/Backend/BikesRentalServer.Services/BikesService.cs
@@ -156,7 +156,7 @@ namespace BikesRentalServer.Services
             }
 
             _bikesRepository.SetStatus(bike.Id, BikeStatus.Rented);
-            bike = _bikesRepository.Associate(bike.Id, user);
+            bike = _bikesRepository.AssociateWithUser(bike.Id, user.Id);
             return ServiceActionResult.Success(new Bike
             {
                 Description = bike.Description,
@@ -183,7 +183,7 @@ namespace BikesRentalServer.Services
                 return ServiceActionResult.InvalidState<Bike>("Bike not rented by calling user");
 
             _bikesRepository.SetStatus(bike.Id, BikeStatus.Available);
-            bike = _bikesRepository.Associate(bike.Id, station);
+            bike = _bikesRepository.AssociateWithStation(bike.Id, station.Id);
             return ServiceActionResult.Success(new Bike
             {
                 Description = bike.Description,

--- a/Backend/BikesRentalServer.Services/StationsService.cs
+++ b/Backend/BikesRentalServer.Services/StationsService.cs
@@ -57,7 +57,7 @@ namespace BikesRentalServer.Services
             if (station.Status is StationStatus.Blocked && _userContext.Role is UserRole.User)
                 return ServiceActionResult.InvalidState<IEnumerable<Bike>>("User cannot get bikes from blocked station");
 
-            var bikes = station.Bikes.Where(bike => bike.Status is BikeStatus.Available && _reservationsRepository.GetActiveReservation(bike.Id.ToString()) is null);
+            var bikes = station.Bikes.Where(bike => bike.Status is BikeStatus.Available && _reservationsRepository.GetActiveReservation(bike.Id) is null);
             return ServiceActionResult.Success(bikes.Select(bike => new Bike
             {
                 Description = bike.Description,
@@ -95,7 +95,7 @@ namespace BikesRentalServer.Services
             if (station.Bikes.Count > 0)
                 return ServiceActionResult.InvalidState<Station>("Station has bikes");
 
-            station = _stationsRepository.Remove(id);
+            station = _stationsRepository.Remove(station.Id);
             return ServiceActionResult.Success(new Station
             {
                 Bikes = station.Bikes,
@@ -141,7 +141,7 @@ namespace BikesRentalServer.Services
             if (station.Status is StationStatus.Blocked)
                 return ServiceActionResult.InvalidState<Station>("Station already blocked");
 
-            station = _stationsRepository.SetStatus(id, StationStatus.Blocked);
+            station = _stationsRepository.SetStatus(station.Id, StationStatus.Blocked);
             return ServiceActionResult.Success(new Station
             {
                 Bikes = station.Bikes,
@@ -159,7 +159,7 @@ namespace BikesRentalServer.Services
             if (station.Status == StationStatus.Active)
                 return ServiceActionResult.InvalidState<Station>("Station not blocked");
 
-            station = _stationsRepository.SetStatus(id, StationStatus.Active);
+            station = _stationsRepository.SetStatus(station.Id, StationStatus.Active);
             return ServiceActionResult.Success(new Station
             {
                 Bikes = station.Bikes,

--- a/Backend/BikesRentalServer.Tests/RepositoriesTests/BikesRepositoryTests/Associate.cs
+++ b/Backend/BikesRentalServer.Tests/RepositoriesTests/BikesRepositoryTests/Associate.cs
@@ -39,7 +39,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            _bikesRepository.Associate(bike.Id.ToString(), user);
+            _bikesRepository.Associate(bike.Id, user);
             
             bike.User.Should().BeEquivalentTo(user);
             bike.Station.Should().BeNull();
@@ -66,7 +66,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            _bikesRepository.Associate(bike.Id.ToString(), station);
+            _bikesRepository.Associate(bike.Id, station);
             
             bike.Station.Should().BeEquivalentTo(station);
             bike.User.Should().BeNull();
@@ -87,7 +87,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            var result = _bikesRepository.Associate(bike.Id.ToString(), user);
+            var result = _bikesRepository.Associate(bike.Id, user);
             
             result.Should().BeEquivalentTo(bike);
         }
@@ -107,7 +107,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            var result = _bikesRepository.Associate(bike.Id.ToString(), station);
+            var result = _bikesRepository.Associate(bike.Id, station);
             
             result.Should().BeEquivalentTo(bike);
         }
@@ -115,7 +115,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
         [Fact]
         public void AssociateNotExistingBikeWithUserShouldReturnNull()
         {
-            const string id = "id";
+            const int id = 6;
 
             var result = _bikesRepository.Associate(id, new User());
 
@@ -125,7 +125,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
         [Fact]
         public void AssociateNotExistingBikeWithStationShouldReturnNull()
         {
-            const string id = "id";
+            const int id = 6;
 
             var result = _bikesRepository.Associate(id, new Station());
 
@@ -142,7 +142,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            var result = _bikesRepository.Associate(bike.Id.ToString(), new User
+            var result = _bikesRepository.Associate(bike.Id, new User
             {
                 Username = "null",
             });
@@ -160,7 +160,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            var result = _bikesRepository.Associate(bike.Id.ToString(), new Station
+            var result = _bikesRepository.Associate(bike.Id, new Station
             {
                 Name = "name",
             });

--- a/Backend/BikesRentalServer.Tests/RepositoriesTests/BikesRepositoryTests/Associate.cs
+++ b/Backend/BikesRentalServer.Tests/RepositoriesTests/BikesRepositoryTests/Associate.cs
@@ -39,7 +39,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            _bikesRepository.Associate(bike.Id, user);
+            _bikesRepository.AssociateWithUser(bike.Id, user.Id);
             
             bike.User.Should().BeEquivalentTo(user);
             bike.Station.Should().BeNull();
@@ -66,7 +66,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            _bikesRepository.Associate(bike.Id, station);
+            _bikesRepository.AssociateWithStation(bike.Id, station.Id);
             
             bike.Station.Should().BeEquivalentTo(station);
             bike.User.Should().BeNull();
@@ -87,7 +87,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            var result = _bikesRepository.Associate(bike.Id, user);
+            var result = _bikesRepository.AssociateWithUser(bike.Id, user.Id);
             
             result.Should().BeEquivalentTo(bike);
         }
@@ -107,7 +107,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            var result = _bikesRepository.Associate(bike.Id, station);
+            var result = _bikesRepository.AssociateWithStation(bike.Id, station.Id);
             
             result.Should().BeEquivalentTo(bike);
         }
@@ -116,8 +116,9 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
         public void AssociateNotExistingBikeWithUserShouldReturnNull()
         {
             const int id = 6;
+            var user = _dbContext.Users.Add(new User()).Entity;
 
-            var result = _bikesRepository.Associate(id, new User());
+            var result = _bikesRepository.AssociateWithUser(id, user.Id);
 
             result.Should().BeNull();
         }
@@ -126,8 +127,13 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
         public void AssociateNotExistingBikeWithStationShouldReturnNull()
         {
             const int id = 6;
+            var station = _dbContext.Stations.Add(new Station
+                {
+                    Name = "test",
+                })
+                .Entity;
 
-            var result = _bikesRepository.Associate(id, new Station());
+            var result = _bikesRepository.AssociateWithStation(id, station.Id);
 
             result.Should().BeNull();
         }
@@ -135,6 +141,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
         [Fact]
         public void AssociateWithNotExistingUserShouldReturnNull()
         {
+            const int userId = 7;
             var bike = _dbContext.Bikes.Add(new Bike
                 {
                     Status = BikeStatus.Available,
@@ -142,10 +149,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            var result = _bikesRepository.Associate(bike.Id, new User
-            {
-                Username = "null",
-            });
+            var result = _bikesRepository.AssociateWithUser(bike.Id, userId);
 
             result.Should().BeNull();
         }
@@ -153,6 +157,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
         [Fact]
         public void AssociateWithNotExistingStationShouldReturnNull()
         {
+            const int stationId = 7;
             var bike = _dbContext.Bikes.Add(new Bike
                 {
                     Status = BikeStatus.Available,
@@ -160,10 +165,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            var result = _bikesRepository.Associate(bike.Id, new Station
-            {
-                Name = "name",
-            });
+            var result = _bikesRepository.AssociateWithStation(bike.Id, stationId);
 
             result.Should().BeNull();
         }

--- a/Backend/BikesRentalServer.Tests/RepositoriesTests/BikesRepositoryTests/Remove.cs
+++ b/Backend/BikesRentalServer.Tests/RepositoriesTests/BikesRepositoryTests/Remove.cs
@@ -20,7 +20,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
         }
 
         [Fact]
-        public void RemoveUsingIdShouldRemoveBike()
+        public void RemoveShouldRemoveBike()
         {
             var station = _dbContext.Stations.Add(new Station
                 {
@@ -36,37 +36,14 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            _bikesRepository.Remove(bike.Id.ToString());
+            _bikesRepository.Remove(bike.Id);
 
             _dbContext.Bikes.Count().Should().Be(0);
             _dbContext.Bikes.SingleOrDefault(x => x.Id == bike.Id).Should().BeNull();
         }
 
         [Fact]
-        public void RemoveUsingEntityShouldRemoveBike()
-        {
-            var station = _dbContext.Stations.Add(new Station
-                {
-                    Name = "station",
-                })
-                .Entity;
-            var bike = _dbContext.Bikes.Add(new Bike
-                {
-                    Description = "deleted",
-                    Station = station,
-                    Status = BikeStatus.Blocked,
-                })
-                .Entity;
-            _dbContext.SaveChanges();
-
-            _bikesRepository.Remove(bike);
-
-            _dbContext.Bikes.Count().Should().Be(0);
-            _dbContext.Bikes.SingleOrDefault(x => x.Id == bike.Id).Should().BeNull();
-        }
-
-        [Fact]
-        public void RemoveUsingIdShouldReturnRemovedBike()
+        public void RemoveShouldReturnRemovedBike()
         {
             var station = _dbContext.Stations.Add(new Station
                 {
@@ -82,73 +59,15 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            var result = _bikesRepository.Remove(bike.Id.ToString());
+            var result = _bikesRepository.Remove(bike.Id);
 
             result.Should().BeEquivalentTo(bike);
-        }
-
-        [Fact]
-        public void RemoveUsingEntityShouldReturnRemovedBike()
-        {
-            var station = _dbContext.Stations.Add(new Station
-                {
-                    Name = "station",
-                })
-                .Entity;
-            var bike = _dbContext.Bikes.Add(new Bike
-                {
-                    Description = "deleted",
-                    Station = station,
-                    Status = BikeStatus.Reserved,
-                })
-                .Entity;
-            _dbContext.SaveChanges();
-
-            var result = _bikesRepository.Remove(bike);
-
-            result.Should().BeEquivalentTo(bike);
-        }
-
-        [Fact]
-        public void RemoveUsingInvalidIdShouldRemoveNothingAndReturnNull()
-        {
-            const string id = "invalid id";
-            var station = _dbContext.Stations.Add(new Station
-                {
-                    Name = "station",
-                })
-                .Entity;
-            _dbContext.Bikes.AddRange(new []
-            {
-                new Bike
-                {
-                    Description = "duck",
-                    Station = station,
-                },
-                new Bike
-                {
-                    Description = "cat",
-                    Station = station,
-                },
-                new Bike
-                {
-                    Description = "dog",
-                    Station = station,
-                },
-            });
-            _dbContext.SaveChanges();
-
-            var initialBikeCount = _dbContext.Bikes.Count();
-            var result = _bikesRepository.Remove(id);
-
-            _dbContext.Bikes.Count().Should().Be(initialBikeCount);
-            result.Should().BeNull();
         }
 
         [Fact]
         public void RemoveUsingIdOfNotExistingBikeShouldRemoveNothingAndReturnNull()
         {
-            const string id = "5";
+            const int id = 5;
             var station = _dbContext.Stations.Add(new Station
                 {
                     Name = "station",
@@ -179,48 +98,6 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
 
             var initialBikeCount = _dbContext.Bikes.Count();
             var result = _bikesRepository.Remove(id);
-
-            _dbContext.Bikes.Count().Should().Be(initialBikeCount);
-            result.Should().BeNull();
-        }
-
-        [Fact]
-        public void RemoveNotExistingBikeShouldRemoveNothingAndReturnNull()
-        {
-            var station = _dbContext.Stations.Add(new Station
-                {
-                    Name = "station",
-                })
-                .Entity;
-            _dbContext.Bikes.AddRange(new []
-            {
-                new Bike
-                {
-                    Description = "duck",
-                    Station = station,
-                    Id = 2,
-                },
-                new Bike
-                {
-                    Description = "cat",
-                    Station = station,
-                    Id = 3,
-                },
-                new Bike
-                {
-                    Description = "dog",
-                    Station = station,
-                    Id = 4,
-                },
-            });
-            _dbContext.SaveChanges();
-
-            var initialBikeCount = _dbContext.Bikes.Count();
-            var result = _bikesRepository.Remove(new Bike
-            {
-                Id = 6,
-                Description = "other",
-            });
 
             _dbContext.Bikes.Count().Should().Be(initialBikeCount);
             result.Should().BeNull();

--- a/Backend/BikesRentalServer.Tests/RepositoriesTests/BikesRepositoryTests/SetStatus.cs
+++ b/Backend/BikesRentalServer.Tests/RepositoriesTests/BikesRepositoryTests/SetStatus.cs
@@ -29,7 +29,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            _bikesRepository.SetStatus(bike.Id.ToString(), BikeStatus.Available);
+            _bikesRepository.SetStatus(bike.Id, BikeStatus.Available);
 
             bike.Status.Should().Be(BikeStatus.Available);
         }
@@ -45,7 +45,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            var result = _bikesRepository.SetStatus(bike.Id.ToString(), BikeStatus.Available);
+            var result = _bikesRepository.SetStatus(bike.Id, BikeStatus.Available);
 
             result.Should().BeEquivalentTo(bike);
         }
@@ -53,7 +53,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.BikesRepositoryTests
         [Fact]
         public void SetStatusOfNotExistingBikeShouldReturnNull()
         {
-            const string id = "7";
+            const int id = 7;
             
             var result = _bikesRepository.SetStatus(id, BikeStatus.Blocked);
 

--- a/Backend/BikesRentalServer.Tests/RepositoriesTests/ReservationsRepositoryTests/GetActiveReservation.cs
+++ b/Backend/BikesRentalServer.Tests/RepositoriesTests/ReservationsRepositoryTests/GetActiveReservation.cs
@@ -87,7 +87,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.ReservationsRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            var result = _reservationsRepository.GetActiveReservation(bike.Id.ToString());
+            var result = _reservationsRepository.GetActiveReservation(bike.Id);
             
             result.Should().BeEquivalentTo(reservation);
         }
@@ -152,7 +152,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.ReservationsRepositoryTests
             });
             _dbContext.SaveChanges();
 
-            var result = _reservationsRepository.GetActiveReservation(bike.Id.ToString());
+            var result = _reservationsRepository.GetActiveReservation(bike.Id);
             
             result.Should().BeNull();
         }
@@ -160,17 +160,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.ReservationsRepositoryTests
         [Fact]
         public void GetActiveReservationOfNotExistingBikeShouldReturnNull()
         {
-            const string id = "9";
-
-            var result = _reservationsRepository.GetActiveReservation(id);
-
-            result.Should().BeNull();
-        }
-
-        [Fact]
-        public void GetActiveReservationUsingInvalidIdShouldReturnNull()
-        {
-            const string id = "invalid";
+            const int id = 9;
 
             var result = _reservationsRepository.GetActiveReservation(id);
 

--- a/Backend/BikesRentalServer.Tests/RepositoriesTests/ReservationsRepositoryTests/Remove.cs
+++ b/Backend/BikesRentalServer.Tests/RepositoriesTests/ReservationsRepositoryTests/Remove.cs
@@ -20,7 +20,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.ReservationsRepositoryTests
         }
 
         [Fact]
-        public void RemoveUsingIdShouldRemoveReservation()
+        public void RemoveShouldRemoveReservation()
         {
             var reservation = _dbContext.Reservations.Add(new Reservation
                 {
@@ -37,14 +37,14 @@ namespace BikesRentalServer.Tests.RepositoriesTests.ReservationsRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            _reservationsRepository.Remove(reservation.Id.ToString());
+            _reservationsRepository.Remove(reservation.Id);
 
             _dbContext.Reservations.Count().Should().Be(0);
             _dbContext.Reservations.SingleOrDefault(x => x.Id == reservation.Id).Should().BeNull();
         }
 
         [Fact]
-        public void RemoveUsingEntityShouldRemoveReservation()
+        public void RemoveShouldReturnRemovedReservation()
         {
             var reservation = _dbContext.Reservations.Add(new Reservation
                 {
@@ -61,87 +61,15 @@ namespace BikesRentalServer.Tests.RepositoriesTests.ReservationsRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            _reservationsRepository.Remove(reservation);
-
-            _dbContext.Reservations.Count().Should().Be(0);
-            _dbContext.Reservations.SingleOrDefault(x => x.Id == reservation.Id).Should().BeNull();
-        }
-
-        [Fact]
-        public void RemoveUsingIdShouldReturnRemovedReservation()
-        {
-            var reservation = _dbContext.Reservations.Add(new Reservation
-                {
-                    Bike = new Bike
-                    {
-                        Description = "bike",
-                    },
-                    User = new User
-                    {
-                        Username = "user",
-                        Role = UserRole.User,
-                    },
-                })
-                .Entity;
-            _dbContext.SaveChanges();
-
-            var result = _reservationsRepository.Remove(reservation.Id.ToString());
+            var result = _reservationsRepository.Remove(reservation.Id);
 
             result.Should().BeEquivalentTo(reservation);
-        }
-
-        [Fact]
-        public void RemoveUsingEntityShouldReturnRemovedReservation()
-        {
-            var reservation = _dbContext.Reservations.Add(new Reservation
-                {
-                    Bike = new Bike
-                    {
-                        Description = "bike",
-                    },
-                    User = new User
-                    {
-                        Username = "user",
-                        Role = UserRole.User,
-                    },
-                })
-                .Entity;
-            _dbContext.SaveChanges();
-
-            var result = _reservationsRepository.Remove(reservation);
-
-            result.Should().BeEquivalentTo(reservation);
-        }
-
-        [Fact]
-        public void RemoveUsingInvalidIdShouldRemoveNothingAndReturnNull()
-        {
-            const string id = "invalid id";
-            _dbContext.Reservations.Add(new Reservation
-                {
-                    Bike = new Bike
-                    {
-                        Description = "bike",
-                    },
-                    User = new User
-                    {
-                        Username = "user",
-                        Role = UserRole.User,
-                    },
-                });
-            _dbContext.SaveChanges();
-
-            var initialReservationCount = _dbContext.Reservations.Count();
-            var result = _reservationsRepository.Remove(id);
-
-            _dbContext.Reservations.Count().Should().Be(initialReservationCount);
-            result.Should().BeNull();
         }
 
         [Fact]
         public void RemoveUsingIdOfNotExistingReservationShouldRemoveNothingAndReturnNull()
         {
-            const string id = "5";
+            const int id = 5;
             _dbContext.Reservations.Add(new Reservation
                 {
                     Bike = new Bike
@@ -158,33 +86,6 @@ namespace BikesRentalServer.Tests.RepositoriesTests.ReservationsRepositoryTests
 
             var initialReservationCount = _dbContext.Reservations.Count();
             var result = _reservationsRepository.Remove(id);
-
-            _dbContext.Reservations.Count().Should().Be(initialReservationCount);
-            result.Should().BeNull();
-        }
-
-        [Fact]
-        public void RemoveNotExistingReservationShouldRemoveNothingAndReturnNull()
-        {
-            _dbContext.Reservations.Add(new Reservation
-                {
-                    Bike = new Bike
-                    {
-                        Description = "bike",
-                    },
-                    User = new User
-                    {
-                        Username = "user",
-                        Role = UserRole.User,
-                    },
-                });
-            _dbContext.SaveChanges();
-
-            var initialReservationCount = _dbContext.Reservations.Count();
-            var result = _reservationsRepository.Remove(new Reservation
-            {
-                Id = 6,
-            });
 
             _dbContext.Reservations.Count().Should().Be(initialReservationCount);
             result.Should().BeNull();

--- a/Backend/BikesRentalServer.Tests/RepositoriesTests/StationsRepositoryTests/Remove.cs
+++ b/Backend/BikesRentalServer.Tests/RepositoriesTests/StationsRepositoryTests/Remove.cs
@@ -20,7 +20,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.StationsRepositoryTests
         }
 
         [Fact]
-        public void RemoveUsingIdShouldRemoveStation()
+        public void RemoveShouldRemoveStation()
         {
             var station = _dbContext.Stations.Add(new Station
                 {
@@ -29,14 +29,14 @@ namespace BikesRentalServer.Tests.RepositoriesTests.StationsRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            _stationsRepository.Remove(station.Id.ToString());
+            _stationsRepository.Remove(station.Id);
 
             _dbContext.Stations.Count().Should().Be(0);
             _dbContext.Stations.SingleOrDefault(x => x.Id == station.Id).Should().BeNull();
         }
 
         [Fact]
-        public void RemoveUsingEntityShouldRemoveStation()
+        public void RemoveShouldReturnRemovedStation()
         {
             var station = _dbContext.Stations.Add(new Station
                 {
@@ -45,78 +45,15 @@ namespace BikesRentalServer.Tests.RepositoriesTests.StationsRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            _stationsRepository.Remove(station);
-
-            _dbContext.Stations.Count().Should().Be(0);
-            _dbContext.Stations.SingleOrDefault(x => x.Id == station.Id).Should().BeNull();
-        }
-
-        [Fact]
-        public void RemoveUsingIdShouldReturnRemovedStation()
-        {
-            var station = _dbContext.Stations.Add(new Station
-                {
-                    Name = "station",
-                })
-                .Entity;
-            _dbContext.SaveChanges();
-
-            var result = _stationsRepository.Remove(station.Id.ToString());
+            var result = _stationsRepository.Remove(station.Id);
 
             result.Should().BeEquivalentTo(station);
-        }
-
-        [Fact]
-        public void RemoveUsingEntityShouldReturnRemovedStation()
-        {
-            var station = _dbContext.Stations.Add(new Station
-                {
-                    Name = "station",
-                })
-                .Entity;
-            _dbContext.SaveChanges();
-
-            var result = _stationsRepository.Remove(station);
-
-            result.Should().BeEquivalentTo(station);
-        }
-
-        [Fact]
-        public void RemoveUsingInvalidIdShouldRemoveNothingAndReturnNull()
-        {
-            const string id = "invalid id";
-            _dbContext.Stations.AddRange(new []
-            {
-                new Station
-                {
-                    Name = "station1",
-                },
-                new Station
-                {
-                    Name = "station2",
-                },
-                new Station
-                {
-                    Name = "station3",
-                },
-                new Station
-                {
-                    Name = "station5",
-                },
-            });
-            _dbContext.SaveChanges();
-
-            var initialStationCount = _dbContext.Stations.Count();
-            var result = _stationsRepository.Remove(id);
-
-            _dbContext.Stations.Count().Should().Be(initialStationCount);
-            result.Should().BeNull();
         }
 
         [Fact]
         public void RemoveUsingIdOfNotExistingStationShouldRemoveNothingAndReturnNull()
         {
-            const string id = "5";
+            const int id = 5;
             _dbContext.Stations.AddRange(new []
             {
                 new Station
@@ -140,41 +77,6 @@ namespace BikesRentalServer.Tests.RepositoriesTests.StationsRepositoryTests
 
             var initialStationCount = _dbContext.Stations.Count();
             var result = _stationsRepository.Remove(id);
-
-            _dbContext.Stations.Count().Should().Be(initialStationCount);
-            result.Should().BeNull();
-        }
-
-        [Fact]
-        public void RemoveNotExistingStationShouldRemoveNothingAndReturnNull()
-        {
-            _dbContext.Stations.AddRange(new []
-            {
-                new Station
-                {
-                    Name = "station1",
-                },
-                new Station
-                {
-                    Name = "station2",
-                },
-                new Station
-                {
-                    Name = "station3",
-                },
-                new Station
-                {
-                    Name = "station5",
-                },
-            });
-            _dbContext.SaveChanges();
-
-            var initialStationCount = _dbContext.Stations.Count();
-            var result = _stationsRepository.Remove(new Station
-            {
-                Id = 6,
-                Name = "other",
-            });
 
             _dbContext.Stations.Count().Should().Be(initialStationCount);
             result.Should().BeNull();

--- a/Backend/BikesRentalServer.Tests/RepositoriesTests/StationsRepositoryTests/SetStatus.cs
+++ b/Backend/BikesRentalServer.Tests/RepositoriesTests/StationsRepositoryTests/SetStatus.cs
@@ -29,7 +29,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.StationsRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            _stationsRepository.SetStatus(station.Id.ToString(), StationStatus.Active);
+            _stationsRepository.SetStatus(station.Id, StationStatus.Active);
 
             station.Status.Should().Be(BikeStatus.Available);
         }
@@ -45,7 +45,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.StationsRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            var result = _stationsRepository.SetStatus(station.Id.ToString(), StationStatus.Active);
+            var result = _stationsRepository.SetStatus(station.Id, StationStatus.Active);
 
             result.Should().BeEquivalentTo(station);
         }
@@ -53,7 +53,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.StationsRepositoryTests
         [Fact]
         public void SetStatusOfNotExistingBikeShouldReturnNull()
         {
-            const string id = "7";
+            const int id = 7;
             
             var result = _stationsRepository.SetStatus(id, StationStatus.Blocked);
 

--- a/Backend/BikesRentalServer.Tests/RepositoriesTests/UsersRepositoryTests/Remove.cs
+++ b/Backend/BikesRentalServer.Tests/RepositoriesTests/UsersRepositoryTests/Remove.cs
@@ -20,7 +20,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.UsersRepositoryTests
         }
 
         [Fact]
-        public void RemoveUsingIdShouldRemoveUser()
+        public void RemoveShouldRemoveUser()
         {
             var user = _dbContext.Users.Add(new User
                 {
@@ -29,14 +29,14 @@ namespace BikesRentalServer.Tests.RepositoriesTests.UsersRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            _usersRepository.Remove(user.Id.ToString());
+            _usersRepository.Remove(user.Id);
 
             _dbContext.Users.Count(x => x.Role == UserRole.User).Should().Be(0);
             _dbContext.Users.SingleOrDefault(x => x.Id == user.Id).Should().BeNull();
         }
 
         [Fact]
-        public void RemoveUsingEntityShouldRemoveUser()
+        public void RemoveShouldReturnRemovedUser()
         {
             var user = _dbContext.Users.Add(new User
                 {
@@ -45,74 +45,15 @@ namespace BikesRentalServer.Tests.RepositoriesTests.UsersRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            _usersRepository.Remove(user);
-
-            _dbContext.Users.Count(x => x.Role == UserRole.User).Should().Be(0);
-            _dbContext.Users.SingleOrDefault(x => x.Id == user.Id).Should().BeNull();
-        }
-
-        [Fact]
-        public void RemoveUsingIdShouldReturnRemovedUser()
-        {
-            var user = _dbContext.Users.Add(new User
-                {
-                    Username = "user",
-                })
-                .Entity;
-            _dbContext.SaveChanges();
-
-            var result = _usersRepository.Remove(user.Id.ToString());
+            var result = _usersRepository.Remove(user.Id);
 
             result.Should().BeEquivalentTo(user);
-        }
-
-        [Fact]
-        public void RemoveUsingEntityShouldReturnRemovedUser()
-        {
-            var user = _dbContext.Users.Add(new User
-                {
-                    Username = "user",
-                })
-                .Entity;
-            _dbContext.SaveChanges();
-
-            var result = _usersRepository.Remove(user);
-
-            result.Should().BeEquivalentTo(user);
-        }
-
-        [Fact]
-        public void RemoveUsingInvalidIdShouldRemoveNothingAndReturnNull()
-        {
-            const string id = "invalid id";
-            _dbContext.Users.AddRange(new []
-            {
-                new User
-                {
-                    Username = "user1",
-                },
-                new User
-                {
-                    Username = "user2",
-                },
-                new User
-                {
-                    Username = "user3",
-                },
-            });
-            _dbContext.SaveChanges();
-
-            var initialUserCount = _dbContext.Users.Count(x => x.Role == UserRole.User);
-            var result = _usersRepository.Remove(id);
-
-            _dbContext.Users.Count(x => x.Role == UserRole.User).Should().Be(initialUserCount);
-            result.Should().BeNull();
         }
 
         [Fact]
         public void RemoveUsingIdOfNotExistingUserShouldRemoveNothingAndReturnNull()
         {
-            const string id = "5";
+            const int id = 5;
             _dbContext.Users.AddRange(new []
             {
                 new User
@@ -132,37 +73,6 @@ namespace BikesRentalServer.Tests.RepositoriesTests.UsersRepositoryTests
 
             var initialUserCount = _dbContext.Users.Count(x => x.Role == UserRole.User);
             var result = _usersRepository.Remove(id);
-
-            _dbContext.Users.Count(x => x.Role == UserRole.User).Should().Be(initialUserCount);
-            result.Should().BeNull();
-        }
-
-        [Fact]
-        public void RemoveNotExistingUserShouldRemoveNothingAndReturnNull()
-        {
-            _dbContext.Users.AddRange(new []
-            {
-                new User
-                {
-                    Username = "user1",
-                },
-                new User
-                {
-                    Username = "user2",
-                },
-                new User
-                {
-                    Username = "user3",
-                },
-            });
-            _dbContext.SaveChanges();
-
-            var initialUserCount = _dbContext.Users.Count(x => x.Role == UserRole.User);
-            var result = _usersRepository.Remove(new User
-            {
-                Username = "piotr",
-                Id = 27,
-            });
 
             _dbContext.Users.Count(x => x.Role == UserRole.User).Should().Be(initialUserCount);
             result.Should().BeNull();

--- a/Backend/BikesRentalServer.Tests/RepositoriesTests/UsersRepositoryTests/SetStatus.cs
+++ b/Backend/BikesRentalServer.Tests/RepositoriesTests/UsersRepositoryTests/SetStatus.cs
@@ -29,7 +29,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.UsersRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            _usersRepository.SetStatus(user.Id.ToString(), UserStatus.Blocked);
+            _usersRepository.SetStatus(user.Id, UserStatus.Blocked);
 
             user.Status.Should().Be(UserStatus.Blocked);
         }
@@ -45,7 +45,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.UsersRepositoryTests
                 .Entity;
             _dbContext.SaveChanges();
 
-            var result = _usersRepository.SetStatus(user.Id.ToString(), UserStatus.Blocked);
+            var result = _usersRepository.SetStatus(user.Id, UserStatus.Blocked);
 
             result.Should().BeEquivalentTo(user);
         }
@@ -53,7 +53,7 @@ namespace BikesRentalServer.Tests.RepositoriesTests.UsersRepositoryTests
         [Fact]
         public void SetStatusOfNotExistingUserShouldReturnNull()
         {
-            const string id = "7";
+            const int id = 7;
             
             var result = _usersRepository.SetStatus(id, UserStatus.Active);
 

--- a/Backend/BikesRentalServer.Tests/ServicesTests/BikesServiceTests/BlockBike.cs
+++ b/Backend/BikesRentalServer.Tests/ServicesTests/BikesServiceTests/BlockBike.cs
@@ -12,7 +12,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
         public void BlockBikeShouldSucceed()
         {
             const int bikeId = 123;
-            BikesRepository.Setup(r => r.SetStatus(It.IsAny<string>(), It.IsAny<BikeStatus>()))
+            BikesRepository.Setup(r => r.SetStatus(It.IsAny<int>(), It.IsAny<BikeStatus>()))
                 .Returns(new Bike
                 {
                     Id = bikeId,
@@ -40,7 +40,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
         public void BlockBikeShouldChangeBikeStatusForBlocked()
         {
             const int bikeId = 123;
-            BikesRepository.Setup(r => r.SetStatus(It.Is<string>(id => id == bikeId.ToString()), It.Is<BikeStatus>(b => b == BikeStatus.Blocked)))
+            BikesRepository.Setup(r => r.SetStatus(It.Is<int>(id => id == bikeId), It.Is<BikeStatus>(b => b == BikeStatus.Blocked)))
                 .Returns(new Bike())
                 .Verifiable();
             BikesRepository.Setup(r => r.Get(It.IsAny<string>()))
@@ -60,7 +60,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
         [Fact]
         public void BlockNotExistingBikeShouldReturnEntityNotFound()
         {
-            BikesRepository.Setup(r => r.SetStatus(It.IsAny<string>(), It.IsAny<BikeStatus>())).Verifiable();
+            BikesRepository.Setup(r => r.SetStatus(It.IsAny<int>(), It.IsAny<BikeStatus>())).Verifiable();
             BikesRepository.Setup(r => r.Get(It.IsAny<string>())).Returns((Bike)null);
 
             var bikesService = GetBikesService();
@@ -68,14 +68,14 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
 
             result.Status.Should().Be(Status.EntityNotFound);
             result.Object.Should().BeNull();
-            BikesRepository.Verify(r => r.SetStatus(It.IsAny<string>(), It.IsAny<BikeStatus>()), Times.Never);
+            BikesRepository.Verify(r => r.SetStatus(It.IsAny<int>(), It.IsAny<BikeStatus>()), Times.Never);
         }
 
         [Fact] 
         public void BlockAlreadyBlockedBikeShouldReturnInvalidState()
         {
             const int bikeId = 123;
-            BikesRepository.Setup(r => r.SetStatus(It.IsAny<string>(), It.IsAny<BikeStatus>())).Verifiable();
+            BikesRepository.Setup(r => r.SetStatus(It.IsAny<int>(), It.IsAny<BikeStatus>())).Verifiable();
             BikesRepository.Setup(r => r.Get(It.IsAny<string>()))
                 .Returns(new Bike
                 {
@@ -88,14 +88,14 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
 
             result.Status.Should().Be(Status.InvalidState);
             result.Object.Should().BeNull();
-            BikesRepository.Verify(r => r.SetStatus(It.IsAny<string>(), It.IsAny<BikeStatus>()), Times.Never);
+            BikesRepository.Verify(r => r.SetStatus(It.IsAny<int>(), It.IsAny<BikeStatus>()), Times.Never);
         }
 
         [Fact] 
         public void BlockRentedBikeShouldReturnInvalidState()
         {
             const int bikeId = 123;
-            BikesRepository.Setup(r => r.SetStatus(It.IsAny<string>(), It.IsAny<BikeStatus>())).Verifiable();
+            BikesRepository.Setup(r => r.SetStatus(It.IsAny<int>(), It.IsAny<BikeStatus>())).Verifiable();
             BikesRepository.Setup(r => r.Get(It.IsAny<string>()))
                 .Returns(new Bike
                 {
@@ -113,7 +113,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
 
             result.Status.Should().Be(Status.InvalidState);
             result.Object.Should().BeNull();
-            BikesRepository.Verify(r => r.SetStatus(It.IsAny<string>(), It.IsAny<BikeStatus>()), Times.Never);
+            BikesRepository.Verify(r => r.SetStatus(It.IsAny<int>(), It.IsAny<BikeStatus>()), Times.Never);
         }
     }
 }

--- a/Backend/BikesRentalServer.Tests/ServicesTests/BikesServiceTests/CancelBikeReservation.cs
+++ b/Backend/BikesRentalServer.Tests/ServicesTests/BikesServiceTests/CancelBikeReservation.cs
@@ -19,7 +19,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
             };
 
             BikesRepository.Setup(r => r.Get(It.IsAny<string>())).Returns(bike);
-            ReservationsRepository.Setup(r => r.GetActiveReservation(It.IsAny<string>()))
+            ReservationsRepository.Setup(r => r.GetActiveReservation(It.IsAny<int>()))
                 .Returns(new Reservation
                 {
                     Bike = bike,
@@ -46,12 +46,12 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
             };
 
             BikesRepository.Setup(r => r.Get(It.IsAny<string>())).Returns(bike);
-            ReservationsRepository.Setup(r => r.GetActiveReservation(It.IsAny<string>()))
+            ReservationsRepository.Setup(r => r.GetActiveReservation(It.IsAny<int>()))
                 .Returns(new Reservation
                 {
                     Bike = bike,
                 });
-            BikesRepository.Setup(r => r.SetStatus(It.IsAny<string>(), BikeStatus.Available)).Verifiable();
+            BikesRepository.Setup(r => r.SetStatus(It.IsAny<int>(), BikeStatus.Available)).Verifiable();
 
             var bikesService = GetBikesService();
             var result = bikesService.CancelBikeReservation(bikeId.ToString());
@@ -64,15 +64,15 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
         public void CancelReservationOfNotExistingBikeShouldReturnEntityNotFound()
         {
             BikesRepository.Setup(r => r.Get(It.IsAny<string>())).Returns((Bike)null);
-            ReservationsRepository.Setup(r => r.GetActiveReservation(It.IsAny<string>())).Returns((Reservation)null);
-            ReservationsRepository.Setup(r => r.Remove(It.IsAny<Reservation>())).Verifiable();
+            ReservationsRepository.Setup(r => r.GetActiveReservation(It.IsAny<int>())).Returns((Reservation)null);
+            ReservationsRepository.Setup(r => r.Remove(It.IsAny<int>())).Verifiable();
 
             var bikesService = GetBikesService();
             var result = bikesService.CancelBikeReservation("123");
 
             result.Status.Should().Be(Status.EntityNotFound);
             result.Object.Should().BeNull();
-            ReservationsRepository.Verify(r => r.Remove(It.IsAny<Reservation>()), Times.Never);
+            ReservationsRepository.Verify(r => r.Remove(It.IsAny<int>()), Times.Never);
         }
 
         [Fact]
@@ -86,15 +86,15 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
             };
 
             BikesRepository.Setup(r => r.Get(It.IsAny<string>())).Returns(bike);
-            ReservationsRepository.Setup(r => r.GetActiveReservation(It.IsAny<string>())).Returns((Reservation)null);
-            ReservationsRepository.Setup(r => r.Remove(It.IsAny<Reservation>())).Verifiable();
+            ReservationsRepository.Setup(r => r.GetActiveReservation(It.IsAny<int>())).Returns((Reservation)null);
+            ReservationsRepository.Setup(r => r.Remove(It.IsAny<int>())).Verifiable();
 
             var bikesService = GetBikesService();
             var result = bikesService.CancelBikeReservation(bikeId.ToString());
 
             result.Status.Should().Be(Status.InvalidState);
             result.Object.Should().BeNull();
-            ReservationsRepository.Verify(r => r.Remove(It.IsAny<Reservation>()), Times.Never);
+            ReservationsRepository.Verify(r => r.Remove(It.IsAny<int>()), Times.Never);
         }
     }
 }

--- a/Backend/BikesRentalServer.Tests/ServicesTests/BikesServiceTests/GiveBikeBack.cs
+++ b/Backend/BikesRentalServer.Tests/ServicesTests/BikesServiceTests/GiveBikeBack.cs
@@ -30,7 +30,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                     Status = BikeStatus.Available,
                     User = user,
                 });
-            BikesRepository.Setup(r => r.Associate(It.IsAny<int>(), station))
+            BikesRepository.Setup(r => r.AssociateWithStation(It.IsAny<int>(), station.Id))
                 .Returns(new Bike
                 {
                     Id = bikeId,
@@ -68,7 +68,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                     Status = BikeStatus.Available,
                     User = user,
                 });
-            BikesRepository.Setup(r => r.Associate(It.IsAny<int>(), It.Is<Station>(s => s.Id == station.Id)))
+            BikesRepository.Setup(r => r.AssociateWithStation(It.IsAny<int>(), station.Id))
                 .Returns(new Bike
                 {
                     Id = bikeId,
@@ -103,14 +103,14 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                     Status = BikeStatus.Available,
                     User = user,
                 });
-            BikesRepository.Setup(r => r.Associate(It.IsAny<int>(), It.IsAny<Station>())).Verifiable();
+            BikesRepository.Setup(r => r.AssociateWithStation(It.IsAny<int>(), It.IsAny<int>())).Verifiable();
 
             var bikesService = GetBikesService(user.Username);
             var result = bikesService.GiveBikeBack(bikeId.ToString(), "1");
 
             result.Status.Should().Be(Status.EntityNotFound);
             result.Object.Should().BeNull();
-            BikesRepository.Verify(r => r.Associate(It.IsAny<int>(), It.IsAny<Station>()), Times.Never);
+            BikesRepository.Verify(r => r.AssociateWithStation(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
         }
 
         [Fact]
@@ -129,14 +129,14 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
             };
             StationsRepository.Setup(r => r.Get(It.IsAny<string>())).Returns(station);
             BikesRepository.Setup(r => r.Get(It.IsAny<string>())).Returns((Bike)null);
-            BikesRepository.Setup(r => r.Associate(It.IsAny<int>(), station)).Verifiable();
+            BikesRepository.Setup(r => r.AssociateWithStation(It.IsAny<int>(), station.Id)).Verifiable();
             
             var bikesService = GetBikesService(thisUser.Username);
             var result = bikesService.GiveBikeBack("123", stationId.ToString());
 
             result.Status.Should().Be(Status.EntityNotFound);
             result.Object.Should().BeNull();
-            BikesRepository.Verify(r => r.Associate(It.IsAny<int>(), It.IsAny<Station>()), Times.Never);
+            BikesRepository.Verify(r => r.AssociateWithStation(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
         }
 
         [Fact]
@@ -165,14 +165,14 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                     Id = bikeId,
                     User = otherUser,
                 });
-            BikesRepository.Setup(r => r.Associate(It.IsAny<int>(), station)).Verifiable();
+            BikesRepository.Setup(r => r.AssociateWithStation(It.IsAny<int>(), station.Id)).Verifiable();
 
             var bikesService = GetBikesService(user.Username);
             var result = bikesService.GiveBikeBack(bikeId.ToString(), station.Id.ToString());
 
             result.Status.Should().Be(Status.InvalidState);
             result.Object.Should().BeNull();
-            BikesRepository.Verify(r => r.Associate(It.IsAny<int>(), It.IsAny<Station>()), Times.Never);
+            BikesRepository.Verify(r => r.AssociateWithStation(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
         }
 
         [Fact]
@@ -191,14 +191,14 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                 {
                     Id = bikeId,
                 });
-            BikesRepository.Setup(r => r.Associate(It.IsAny<int>(), It.IsAny<User>())).Verifiable();
+            BikesRepository.Setup(r => r.AssociateWithUser(It.IsAny<int>(), It.IsAny<int>())).Verifiable();
 
             var bikesService = GetBikesService();
             var result = bikesService.GiveBikeBack(bikeId.ToString(), stationId.ToString());
 
             result.Status.Should().Be(Status.InvalidState);
             result.Object.Should().BeNull();
-            BikesRepository.Verify(r => r.Associate(It.IsAny<int>(), It.IsAny<User>()), Times.Never);
+            BikesRepository.Verify(r => r.AssociateWithUser(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
         }
     }
 }

--- a/Backend/BikesRentalServer.Tests/ServicesTests/BikesServiceTests/GiveBikeBack.cs
+++ b/Backend/BikesRentalServer.Tests/ServicesTests/BikesServiceTests/GiveBikeBack.cs
@@ -30,7 +30,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                     Status = BikeStatus.Available,
                     User = user,
                 });
-            BikesRepository.Setup(r => r.Associate(It.IsAny<string>(), station))
+            BikesRepository.Setup(r => r.Associate(It.IsAny<int>(), station))
                 .Returns(new Bike
                 {
                     Id = bikeId,
@@ -68,7 +68,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                     Status = BikeStatus.Available,
                     User = user,
                 });
-            BikesRepository.Setup(r => r.Associate(It.IsAny<string>(), It.Is<Station>(s => s.Id == station.Id)))
+            BikesRepository.Setup(r => r.Associate(It.IsAny<int>(), It.Is<Station>(s => s.Id == station.Id)))
                 .Returns(new Bike
                 {
                     Id = bikeId,
@@ -103,14 +103,14 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                     Status = BikeStatus.Available,
                     User = user,
                 });
-            BikesRepository.Setup(r => r.Associate(It.IsAny<string>(), It.IsAny<Station>())).Verifiable();
+            BikesRepository.Setup(r => r.Associate(It.IsAny<int>(), It.IsAny<Station>())).Verifiable();
 
             var bikesService = GetBikesService(user.Username);
             var result = bikesService.GiveBikeBack(bikeId.ToString(), "1");
 
             result.Status.Should().Be(Status.EntityNotFound);
             result.Object.Should().BeNull();
-            BikesRepository.Verify(r => r.Associate(It.IsAny<string>(), It.IsAny<Station>()), Times.Never);
+            BikesRepository.Verify(r => r.Associate(It.IsAny<int>(), It.IsAny<Station>()), Times.Never);
         }
 
         [Fact]
@@ -129,14 +129,14 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
             };
             StationsRepository.Setup(r => r.Get(It.IsAny<string>())).Returns(station);
             BikesRepository.Setup(r => r.Get(It.IsAny<string>())).Returns((Bike)null);
-            BikesRepository.Setup(r => r.Associate(It.IsAny<string>(), station)).Verifiable();
+            BikesRepository.Setup(r => r.Associate(It.IsAny<int>(), station)).Verifiable();
             
             var bikesService = GetBikesService(thisUser.Username);
             var result = bikesService.GiveBikeBack("123", stationId.ToString());
 
             result.Status.Should().Be(Status.EntityNotFound);
             result.Object.Should().BeNull();
-            BikesRepository.Verify(r => r.Associate(It.IsAny<string>(), It.IsAny<Station>()), Times.Never);
+            BikesRepository.Verify(r => r.Associate(It.IsAny<int>(), It.IsAny<Station>()), Times.Never);
         }
 
         [Fact]
@@ -165,14 +165,14 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                     Id = bikeId,
                     User = otherUser,
                 });
-            BikesRepository.Setup(r => r.Associate(It.IsAny<string>(), station)).Verifiable();
+            BikesRepository.Setup(r => r.Associate(It.IsAny<int>(), station)).Verifiable();
 
             var bikesService = GetBikesService(user.Username);
             var result = bikesService.GiveBikeBack(bikeId.ToString(), station.Id.ToString());
 
             result.Status.Should().Be(Status.InvalidState);
             result.Object.Should().BeNull();
-            BikesRepository.Verify(r => r.Associate(It.IsAny<string>(), It.IsAny<Station>()), Times.Never);
+            BikesRepository.Verify(r => r.Associate(It.IsAny<int>(), It.IsAny<Station>()), Times.Never);
         }
 
         [Fact]
@@ -191,14 +191,14 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                 {
                     Id = bikeId,
                 });
-            BikesRepository.Setup(r => r.Associate(It.IsAny<string>(), It.IsAny<User>())).Verifiable();
+            BikesRepository.Setup(r => r.Associate(It.IsAny<int>(), It.IsAny<User>())).Verifiable();
 
             var bikesService = GetBikesService();
             var result = bikesService.GiveBikeBack(bikeId.ToString(), stationId.ToString());
 
             result.Status.Should().Be(Status.InvalidState);
             result.Object.Should().BeNull();
-            BikesRepository.Verify(r => r.Associate(It.IsAny<string>(), It.IsAny<User>()), Times.Never);
+            BikesRepository.Verify(r => r.Associate(It.IsAny<int>(), It.IsAny<User>()), Times.Never);
         }
     }
 }

--- a/Backend/BikesRentalServer.Tests/ServicesTests/BikesServiceTests/RemoveBike.cs
+++ b/Backend/BikesRentalServer.Tests/ServicesTests/BikesServiceTests/RemoveBike.cs
@@ -19,7 +19,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                     Id = bikeId,
                     Status = BikeStatus.Blocked,
                 });
-            BikesRepository.Setup(r => r.Remove(It.IsAny<Bike>())).Returns(new Bike()).Verifiable();
+            BikesRepository.Setup(r => r.Remove(It.IsAny<int>())).Returns(new Bike()).Verifiable();
 
             var bikesService = GetBikesService();
             var result = bikesService.RemoveBike(bikeId.ToString());
@@ -33,14 +33,14 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
         {
             const int bikeId = 1234;
             BikesRepository.Setup(r => r.Get(It.IsAny<string>())).Returns((Bike)null);
-            BikesRepository.Setup(r => r.Remove(It.IsAny<Bike>())).Verifiable();
+            BikesRepository.Setup(r => r.Remove(It.IsAny<int>())).Verifiable();
 
             var bikesService = GetBikesService();
             var result = bikesService.RemoveBike(bikeId.ToString());
 
             result.Status.Should().Be(Status.EntityNotFound);
             result.Object.Should().BeNull();
-            BikesRepository.Verify(r => r.Remove(It.IsAny<Bike>()), Times.Never);
+            BikesRepository.Verify(r => r.Remove(It.IsAny<int>()), Times.Never);
         }
 
         [Fact]
@@ -52,14 +52,14 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                 Id = bikeId,
                 Status = BikeStatus.Available,
             });
-            BikesRepository.Setup(r => r.Remove(It.IsAny<Bike>())).Verifiable();
+            BikesRepository.Setup(r => r.Remove(It.IsAny<int>())).Verifiable();
 
             var bikesService = GetBikesService();
             var result = bikesService.RemoveBike(bikeId.ToString());
 
             result.Status.Should().Be(Status.InvalidState);
             result.Object.Should().BeNull();
-            BikesRepository.Verify(r => r.Remove(It.IsAny<Bike>()), Times.Never);
+            BikesRepository.Verify(r => r.Remove(It.IsAny<int>()), Times.Never);
         }
 
         [Fact]
@@ -75,13 +75,13 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                 Status = BikeStatus.Blocked,
             };
             BikesRepository.Setup(r => r.Get(It.IsAny<string>())).Returns(bike);
-            BikesRepository.Setup(r => r.Remove(It.IsAny<Bike>())).Verifiable();
+            BikesRepository.Setup(r => r.Remove(It.IsAny<int>())).Verifiable();
             
             var bikesService = GetBikesService();
             Action action = () => bikesService.RemoveBike(bike.Id.ToString());
 
             action.Should().Throw<InvalidOperationException>();
-            BikesRepository.Verify(r => r.Remove(It.IsAny<Bike>()), Times.Never);
+            BikesRepository.Verify(r => r.Remove(It.IsAny<int>()), Times.Never);
         }
     }
 }

--- a/Backend/BikesRentalServer.Tests/ServicesTests/BikesServiceTests/RentBike.cs
+++ b/Backend/BikesRentalServer.Tests/ServicesTests/BikesServiceTests/RentBike.cs
@@ -31,8 +31,8 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                         Status = StationStatus.Active,
                     },
                 });
-            BikesRepository.Setup(r => r.SetStatus(It.IsAny<string>(), BikeStatus.Rented)).Verifiable();
-            BikesRepository.Setup(r => r.Associate(It.IsAny<string>(), It.IsAny<User>()))
+            BikesRepository.Setup(r => r.SetStatus(It.IsAny<int>(), BikeStatus.Rented)).Verifiable();
+            BikesRepository.Setup(r => r.Associate(It.IsAny<int>(), It.IsAny<User>()))
                 .Returns(new Bike
                 {
                     Id = bikeId,
@@ -77,7 +77,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                         Id = 1,
                     },
                 });
-            BikesRepository.Setup(r => r.Associate(bikeId.ToString(), It.IsAny<User>()))
+            BikesRepository.Setup(r => r.Associate(bikeId, It.IsAny<User>()))
                 .Returns(new Bike
                 {
                     Id = bikeId,
@@ -116,7 +116,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
 
             result.Status.Should().Be(Status.EntityNotFound);
             result.Object.Should().BeNull();
-            BikesRepository.Verify(r => r.SetStatus(It.IsAny<string>(), It.IsAny<BikeStatus>()), Times.Never);
+            BikesRepository.Verify(r => r.SetStatus(It.IsAny<int>(), It.IsAny<BikeStatus>()), Times.Never);
         }
 
         [Fact]
@@ -145,14 +145,14 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                         Status = StationStatus.Active,
                     },
                 });
-            BikesRepository.Setup(r => r.Associate(It.IsAny<string>(), It.IsAny<User>())).Verifiable();
+            BikesRepository.Setup(r => r.Associate(It.IsAny<int>(), It.IsAny<User>())).Verifiable();
 
             var bikesService = GetBikesService(user.Username);
             var result = bikesService.RentBike(bikeId.ToString());
 
             result.Status.Should().Be(Status.InvalidState);
             result.Object.Should().BeNull();
-            BikesRepository.Verify(r => r.SetStatus(It.IsAny<string>(), It.IsAny<BikeStatus>()), Times.Never);
+            BikesRepository.Verify(r => r.SetStatus(It.IsAny<int>(), It.IsAny<BikeStatus>()), Times.Never);
         }
 
         [Fact]
@@ -191,7 +191,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
 
             result.Status.Should().Be(Status.InvalidState);
             result.Object.Should().BeNull();
-            BikesRepository.Verify(r => r.SetStatus(It.IsAny<string>(), It.IsAny<BikeStatus>()), Times.Never);
+            BikesRepository.Verify(r => r.SetStatus(It.IsAny<int>(), It.IsAny<BikeStatus>()), Times.Never);
         }
 
         [Fact]
@@ -218,14 +218,14 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                         Id = 1,
                     },
                 });
-            BikesRepository.Setup(r => r.Associate(It.IsAny<string>(), It.IsAny<Station>())).Verifiable();
+            BikesRepository.Setup(r => r.Associate(It.IsAny<int>(), It.IsAny<Station>())).Verifiable();
 
             var bikesService = GetBikesService(user.Username);
             var result = bikesService.RentBike(bikeId.ToString());
 
             result.Status.Should().Be(Status.InvalidState);
             result.Object.Should().BeNull();
-            BikesRepository.Verify(r => r.Associate(It.IsAny<string>(), It.IsAny<Station>()), Times.Never);
+            BikesRepository.Verify(r => r.Associate(It.IsAny<int>(), It.IsAny<Station>()), Times.Never);
         }
 
         [Fact]
@@ -252,20 +252,20 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
 
             UsersRepository.Setup(r => r.GetByUsername(It.IsAny<string>())).Returns(user);
             BikesRepository.Setup(r => r.Get(It.IsAny<string>())).Returns(bike);
-            BikesRepository.Setup(r => r.Associate(bikeId.ToString(), It.IsAny<User>()))
+            BikesRepository.Setup(r => r.Associate(bikeId, It.IsAny<User>()))
                 .Returns(new Bike
                 {
                     User = user,
                     Id = bikeId,
                 })
                 .Verifiable();
-            ReservationsRepository.Setup(r => r.GetActiveReservation(bikeId.ToString()))
+            ReservationsRepository.Setup(r => r.GetActiveReservation(bikeId))
                 .Returns(new Reservation
                 {
                     Bike = bike,
                     User = user,
                 });
-            ReservationsRepository.Setup(r => r.Remove(It.IsAny<Reservation>())).Verifiable();
+            ReservationsRepository.Setup(r => r.Remove(It.IsAny<int>())).Verifiable();
             
             var bikesService = GetBikesService(user.Username);
             var result = bikesService.RentBike(bikeId.ToString());
@@ -309,22 +309,22 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
 
             UsersRepository.Setup(r => r.GetByUsername(It.IsAny<string>())).Returns(user);
             BikesRepository.Setup(r => r.Get(It.IsAny<string>())).Returns(bike);
-            BikesRepository.Setup(r => r.Associate(bikeId.ToString(), It.IsAny<User>())).Verifiable();
-            ReservationsRepository.Setup(r => r.GetActiveReservation(bikeId.ToString()))
+            BikesRepository.Setup(r => r.Associate(bikeId, It.IsAny<User>())).Verifiable();
+            ReservationsRepository.Setup(r => r.GetActiveReservation(bikeId))
                 .Returns(new Reservation
                 {
                     Bike = bike,
                     User = otherUser,
                 });
-            ReservationsRepository.Setup(r => r.Remove(It.IsAny<Reservation>())).Verifiable();
+            ReservationsRepository.Setup(r => r.Remove(It.IsAny<int>())).Verifiable();
 
             var bikesService = GetBikesService(user.Username);
             var result = bikesService.RentBike(bikeId.ToString());
 
             result.Status.Should().Be(Status.InvalidState);
             result.Object.Should().BeNull();
-            ReservationsRepository.Verify(r => r.Remove(It.IsAny<Reservation>()), Times.Never);
-            BikesRepository.Verify(r => r.Associate(bikeId.ToString(), It.IsAny<User>()), Times.Never);
+            ReservationsRepository.Verify(r => r.Remove(It.IsAny<int>()), Times.Never);
+            BikesRepository.Verify(r => r.Associate(bikeId, It.IsAny<User>()), Times.Never);
         }
 
         [Fact]
@@ -340,14 +340,14 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                 },
             };
             BikesRepository.Setup(r => r.Get(It.IsAny<string>())).Returns(bike);
-            BikesRepository.Setup(r => r.Associate(It.IsAny<string>(), It.IsAny<User>())).Verifiable();
+            BikesRepository.Setup(r => r.Associate(It.IsAny<int>(), It.IsAny<User>())).Verifiable();
 
             var bikesService = GetBikesService();
             var result = bikesService.RentBike(bike.Id.ToString());
 
             result.Status.Should().Be(Status.InvalidState);
             result.Object.Should().BeNull();
-            BikesRepository.Verify(r => r.Associate(It.IsAny<string>(), It.IsAny<User>()), Times.Never);
+            BikesRepository.Verify(r => r.Associate(It.IsAny<int>(), It.IsAny<User>()), Times.Never);
         }
 
         [Fact]
@@ -369,14 +369,14 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                         Status = StationStatus.Active,
                     },
                 });
-            BikesRepository.Setup(r => r.Associate(It.IsAny<string>(), user)).Verifiable();
+            BikesRepository.Setup(r => r.Associate(It.IsAny<int>(), user)).Verifiable();
 
             var bikesService = GetBikesService();
             var result = bikesService.RentBike(bikeId.ToString());
 
             result.Status.Should().Be(Status.UserBlocked);
             result.Object.Should().BeNull();
-            BikesRepository.Verify(r => r.Associate(It.IsAny<string>(), user), Times.Never);
+            BikesRepository.Verify(r => r.Associate(It.IsAny<int>(), user), Times.Never);
         }
     }
 }

--- a/Backend/BikesRentalServer.Tests/ServicesTests/BikesServiceTests/RentBike.cs
+++ b/Backend/BikesRentalServer.Tests/ServicesTests/BikesServiceTests/RentBike.cs
@@ -32,7 +32,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                     },
                 });
             BikesRepository.Setup(r => r.SetStatus(It.IsAny<int>(), BikeStatus.Rented)).Verifiable();
-            BikesRepository.Setup(r => r.Associate(It.IsAny<int>(), It.IsAny<User>()))
+            BikesRepository.Setup(r => r.AssociateWithUser(It.IsAny<int>(), It.IsAny<int>()))
                 .Returns(new Bike
                 {
                     Id = bikeId,
@@ -77,7 +77,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                         Id = 1,
                     },
                 });
-            BikesRepository.Setup(r => r.Associate(bikeId, It.IsAny<User>()))
+            BikesRepository.Setup(r => r.AssociateWithUser(bikeId, It.IsAny<int>()))
                 .Returns(new Bike
                 {
                     Id = bikeId,
@@ -145,7 +145,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                         Status = StationStatus.Active,
                     },
                 });
-            BikesRepository.Setup(r => r.Associate(It.IsAny<int>(), It.IsAny<User>())).Verifiable();
+            BikesRepository.Setup(r => r.AssociateWithUser(It.IsAny<int>(), It.IsAny<int>())).Verifiable();
 
             var bikesService = GetBikesService(user.Username);
             var result = bikesService.RentBike(bikeId.ToString());
@@ -218,14 +218,14 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                         Id = 1,
                     },
                 });
-            BikesRepository.Setup(r => r.Associate(It.IsAny<int>(), It.IsAny<Station>())).Verifiable();
+            BikesRepository.Setup(r => r.AssociateWithStation(It.IsAny<int>(), It.IsAny<int>())).Verifiable();
 
             var bikesService = GetBikesService(user.Username);
             var result = bikesService.RentBike(bikeId.ToString());
 
             result.Status.Should().Be(Status.InvalidState);
             result.Object.Should().BeNull();
-            BikesRepository.Verify(r => r.Associate(It.IsAny<int>(), It.IsAny<Station>()), Times.Never);
+            BikesRepository.Verify(r => r.AssociateWithStation(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
         }
 
         [Fact]
@@ -252,7 +252,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
 
             UsersRepository.Setup(r => r.GetByUsername(It.IsAny<string>())).Returns(user);
             BikesRepository.Setup(r => r.Get(It.IsAny<string>())).Returns(bike);
-            BikesRepository.Setup(r => r.Associate(bikeId, It.IsAny<User>()))
+            BikesRepository.Setup(r => r.AssociateWithUser(bikeId, It.IsAny<int>()))
                 .Returns(new Bike
                 {
                     User = user,
@@ -309,7 +309,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
 
             UsersRepository.Setup(r => r.GetByUsername(It.IsAny<string>())).Returns(user);
             BikesRepository.Setup(r => r.Get(It.IsAny<string>())).Returns(bike);
-            BikesRepository.Setup(r => r.Associate(bikeId, It.IsAny<User>())).Verifiable();
+            BikesRepository.Setup(r => r.AssociateWithUser(bikeId, It.IsAny<int>())).Verifiable();
             ReservationsRepository.Setup(r => r.GetActiveReservation(bikeId))
                 .Returns(new Reservation
                 {
@@ -324,7 +324,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
             result.Status.Should().Be(Status.InvalidState);
             result.Object.Should().BeNull();
             ReservationsRepository.Verify(r => r.Remove(It.IsAny<int>()), Times.Never);
-            BikesRepository.Verify(r => r.Associate(bikeId, It.IsAny<User>()), Times.Never);
+            BikesRepository.Verify(r => r.AssociateWithUser(bikeId, It.IsAny<int>()), Times.Never);
         }
 
         [Fact]
@@ -340,14 +340,14 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                 },
             };
             BikesRepository.Setup(r => r.Get(It.IsAny<string>())).Returns(bike);
-            BikesRepository.Setup(r => r.Associate(It.IsAny<int>(), It.IsAny<User>())).Verifiable();
+            BikesRepository.Setup(r => r.AssociateWithUser(It.IsAny<int>(), It.IsAny<int>())).Verifiable();
 
             var bikesService = GetBikesService();
             var result = bikesService.RentBike(bike.Id.ToString());
 
             result.Status.Should().Be(Status.InvalidState);
             result.Object.Should().BeNull();
-            BikesRepository.Verify(r => r.Associate(It.IsAny<int>(), It.IsAny<User>()), Times.Never);
+            BikesRepository.Verify(r => r.AssociateWithUser(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
         }
 
         [Fact]
@@ -356,6 +356,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
             const int bikeId = 2;
             var user = new User
             {
+                Id = 1,
                 Status = UserStatus.Blocked,
             };
             UsersRepository.Setup(r => r.GetByUsername(It.IsAny<string>())).Returns(user).Verifiable();
@@ -369,14 +370,14 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                         Status = StationStatus.Active,
                     },
                 });
-            BikesRepository.Setup(r => r.Associate(It.IsAny<int>(), user)).Verifiable();
+            BikesRepository.Setup(r => r.AssociateWithUser(It.IsAny<int>(), user.Id)).Verifiable();
 
             var bikesService = GetBikesService();
             var result = bikesService.RentBike(bikeId.ToString());
 
             result.Status.Should().Be(Status.UserBlocked);
             result.Object.Should().BeNull();
-            BikesRepository.Verify(r => r.Associate(It.IsAny<int>(), user), Times.Never);
+            BikesRepository.Verify(r => r.AssociateWithUser(It.IsAny<int>(), user.Id), Times.Never);
         }
     }
 }

--- a/Backend/BikesRentalServer.Tests/ServicesTests/BikesServiceTests/ReserveBike.cs
+++ b/Backend/BikesRentalServer.Tests/ServicesTests/BikesServiceTests/ReserveBike.cs
@@ -45,7 +45,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                     },
                 });
             UsersRepository.Setup(r => r.GetByUsername(It.IsAny<string>())).Returns(user);
-            BikesRepository.Setup(r => r.SetStatus(It.IsAny<string>(), BikeStatus.Reserved))
+            BikesRepository.Setup(r => r.SetStatus(It.IsAny<int>(), BikeStatus.Reserved))
                 .Returns(new Bike
                 {
                     Id = bikeId,
@@ -100,7 +100,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
                     },
                 });
             UsersRepository.Setup(r => r.GetByUsername(It.IsAny<string>())).Returns(user);
-            BikesRepository.Setup(r => r.SetStatus(It.IsAny<string>(), BikeStatus.Reserved))
+            BikesRepository.Setup(r => r.SetStatus(It.IsAny<int>(), BikeStatus.Reserved))
                 .Returns(new Bike
                 {
                     Id = bikeId,

--- a/Backend/BikesRentalServer.Tests/ServicesTests/BikesServiceTests/UnblockBike.cs
+++ b/Backend/BikesRentalServer.Tests/ServicesTests/BikesServiceTests/UnblockBike.cs
@@ -13,7 +13,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
         {
             const int bikeId = 123;
 
-            BikesRepository.Setup(r => r.SetStatus(It.IsAny<string>(), It.Is<BikeStatus>(s => s == BikeStatus.Available)))
+            BikesRepository.Setup(r => r.SetStatus(It.IsAny<int>(), It.Is<BikeStatus>(s => s == BikeStatus.Available)))
                 .Returns(new Bike
                 {
                     Id = bikeId,
@@ -40,7 +40,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
         [Fact]
         public void UnlockNotExistingBikeShouldReturnEntityNotFound()
         {
-            BikesRepository.Setup(r => r.SetStatus(It.IsAny<string>(), It.IsAny<BikeStatus>())).Verifiable();
+            BikesRepository.Setup(r => r.SetStatus(It.IsAny<int>(), It.IsAny<BikeStatus>())).Verifiable();
             BikesRepository.Setup(r => r.Get(It.IsAny<string>())).Returns((Bike)null);
 
             var bikesService = GetBikesService();
@@ -48,14 +48,14 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
 
             result.Status.Should().Be(Status.EntityNotFound);
             result.Object.Should().BeNull();
-            BikesRepository.Verify(r => r.SetStatus(It.IsAny<string>(), It.IsAny<BikeStatus>()), Times.Never);
+            BikesRepository.Verify(r => r.SetStatus(It.IsAny<int>(), It.IsAny<BikeStatus>()), Times.Never);
         }
 
         [Fact]
         public void UnlockNotBlockedBikeShouldReturnInvalidState()
         {
             const int bikeId = 123;
-            BikesRepository.Setup(r => r.SetStatus(It.IsAny<string>(), It.IsAny<BikeStatus>())).Verifiable();
+            BikesRepository.Setup(r => r.SetStatus(It.IsAny<int>(), It.IsAny<BikeStatus>())).Verifiable();
             BikesRepository.Setup(r => r.Get(It.IsAny<string>()))
                 .Returns(new Bike
                 {
@@ -68,7 +68,7 @@ namespace BikesRentalServer.Tests.ServicesTests.BikesServiceTests
 
             result.Status.Should().Be(Status.InvalidState);
             result.Object.Should().BeNull();
-            BikesRepository.Verify(r => r.SetStatus(It.IsAny<string>(), It.IsAny<BikeStatus>()), Times.Never);
+            BikesRepository.Verify(r => r.SetStatus(It.IsAny<int>(), It.IsAny<BikeStatus>()), Times.Never);
         }
     }
 }

--- a/Backend/BikesRentalServer.Tests/ServicesTests/StationsServiceTests/BlockStation.cs
+++ b/Backend/BikesRentalServer.Tests/ServicesTests/StationsServiceTests/BlockStation.cs
@@ -18,7 +18,7 @@ namespace BikesRentalServer.Tests.ServicesTests.StationsServiceTests
                 Id = 23,
             };
             StationsRepository.Setup(r => r.Get(It.IsAny<string>())).Returns(station);
-            StationsRepository.Setup(r => r.SetStatus(It.IsAny<string>(), It.Is<StationStatus>(s => s == StationStatus.Blocked)))
+            StationsRepository.Setup(r => r.SetStatus(It.IsAny<int>(), It.Is<StationStatus>(s => s == StationStatus.Blocked)))
                 .Returns(new Station
                 {
                     Name = "Trailer Park",

--- a/Backend/BikesRentalServer.Tests/ServicesTests/StationsServiceTests/RemoveStation.cs
+++ b/Backend/BikesRentalServer.Tests/ServicesTests/StationsServiceTests/RemoveStation.cs
@@ -21,7 +21,7 @@ namespace BikesRentalServer.Tests.ServicesTests.StationsServiceTests
             };
 
             StationsRepository.Setup(r => r.Get(It.IsAny<string>())).Returns(station);
-            StationsRepository.Setup(r => r.Remove(It.Is<string>(id => id == station.Id.ToString()))).Returns(station).Verifiable();
+            StationsRepository.Setup(r => r.Remove(It.Is<int>(id => id == station.Id))).Returns(station).Verifiable();
             
             var stationsService = GetStationsService();
             var result = stationsService.RemoveStation(station.Id.ToString());
@@ -42,7 +42,7 @@ namespace BikesRentalServer.Tests.ServicesTests.StationsServiceTests
             };
 
             StationsRepository.Setup(r => r.Get(It.IsAny<string>())).Returns((Station)null);
-            StationsRepository.Setup(r => r.Remove(It.Is<string>(id => id == station.Id.ToString()))).Returns(station).Verifiable();
+            StationsRepository.Setup(r => r.Remove(It.Is<int>(id => id == station.Id))).Returns(station).Verifiable();
 
             var stationsService = GetStationsService();
             var result = stationsService.RemoveStation("3");

--- a/Backend/BikesRentalServer.Tests/ServicesTests/StationsServiceTests/UnblockStation.cs
+++ b/Backend/BikesRentalServer.Tests/ServicesTests/StationsServiceTests/UnblockStation.cs
@@ -24,7 +24,7 @@ namespace BikesRentalServer.Tests.ServicesTests.StationsServiceTests
                 Id = 23,
             };
             StationsRepository.Setup(r => r.Get(It.IsAny<string>())).Returns(stationBlocked);
-            StationsRepository.Setup(r => r.SetStatus(It.IsAny<string>(), It.Is<StationStatus>(s => s == StationStatus.Active))).Returns(station).Verifiable();
+            StationsRepository.Setup(r => r.SetStatus(It.IsAny<int>(), It.Is<StationStatus>(s => s == StationStatus.Active))).Returns(station).Verifiable();
 
             var stationsService = GetStationsService();
             var result = stationsService.UnblockStation(station.Id.ToString());

--- a/Backend/BikesRentalServer.Tests/ServicesTests/UsersServiceTests/BlockUser.cs
+++ b/Backend/BikesRentalServer.Tests/ServicesTests/UsersServiceTests/BlockUser.cs
@@ -44,7 +44,7 @@ namespace BikesRentalServer.Tests.ServicesTests.UsersServiceTests
         public void BlockUserShouldSetUserStateToBanned()
         {
             const int userId = 2;
-            UsersRepository.Setup(r => r.SetStatus(It.IsAny<string>(), It.Is<UserStatus>(s => s == UserStatus.Blocked)))
+            UsersRepository.Setup(r => r.SetStatus(It.IsAny<int>(), It.Is<UserStatus>(s => s == UserStatus.Blocked)))
                 .Returns(new User
                 {
                     Id = userId,
@@ -90,7 +90,7 @@ namespace BikesRentalServer.Tests.ServicesTests.UsersServiceTests
                     }
                 },
             };
-            UsersRepository.Setup(r => r.SetStatus(It.IsAny<string>(), It.Is<UserStatus>(s => s == UserStatus.Blocked)))
+            UsersRepository.Setup(r => r.SetStatus(It.IsAny<int>(), It.Is<UserStatus>(s => s == UserStatus.Blocked)))
                 .Returns(new User
                 {
                     Id = userId,
@@ -104,7 +104,7 @@ namespace BikesRentalServer.Tests.ServicesTests.UsersServiceTests
                     Status = UserStatus.Active,
                     Reservations = reservations,
                 });
-            ReservationsRepository.Setup(r => r.Remove(It.IsAny<Reservation>())).Returns(new Reservation()).Verifiable();
+            ReservationsRepository.Setup(r => r.Remove(It.IsAny<int>())).Returns(new Reservation()).Verifiable();
 
             var usersService = GetUsersService();
             var response = usersService.BlockUser(userId.ToString());
@@ -112,7 +112,7 @@ namespace BikesRentalServer.Tests.ServicesTests.UsersServiceTests
             response.Status.Should().Be(Status.Success);
             response.Object.Should().NotBeNull();
             response.Object.Reservations.Should().BeEmpty();
-            ReservationsRepository.Verify(r => r.Remove(It.IsAny<Reservation>()), Times.Exactly(reservations.Count));
+            ReservationsRepository.Verify(r => r.Remove(It.IsAny<int>()), Times.Exactly(reservations.Count));
         }
     }
 }

--- a/Backend/BikesRentalServer.Tests/ServicesTests/UsersServiceTests/UnblockUser.cs
+++ b/Backend/BikesRentalServer.Tests/ServicesTests/UsersServiceTests/UnblockUser.cs
@@ -43,7 +43,7 @@ namespace BikesRentalServer.Tests.ServicesTests.UsersServiceTests
         public void UnblockUserSimpleSuccess()
         {
             const string userId = "2";
-            UsersRepository.Setup(r => r.SetStatus(It.IsAny<string>(), It.Is<UserStatus>(s => s == UserStatus.Active)))
+            UsersRepository.Setup(r => r.SetStatus(It.IsAny<int>(), It.Is<UserStatus>(s => s == UserStatus.Active)))
                 .Returns(new User
                 {
                     Id = 2,


### PR DESCRIPTION
# Changes:
1) changed methods such as `Associate` or `Remove` so that they don't accept objects, only ids (changed parameter type or removed overload)
2) changed all methods accepting ids (except of `Get`) to accept `int` instead of `string`

# Motivation
1) I think it's better not to assume object passed as parameter is a valid EF object. It seemed to be alright, but if it ever happened not to be, it could get weird
2) We never really 'naturally'* used the fact that they accepted `string`s - almost all invokes used id with `.ToString()` (those which didn't used input parameter or were tests)

*never had no other reason than it being the only option